### PR TITLE
[FEAT] 회원가입 / 로그인 / 로그아웃 / 토큰 갱신 / 비밀번호 변경 API 구현 (#4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Get pnpm store path
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     ],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
+    "passWithNoTests": true,
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { FirstAidModule } from './first-aid/first-aid.module';
+import { AuthModule } from './auth/auth.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -24,6 +26,8 @@ import { FirstAidModule } from './first-aid/first-aid.module';
       inject: [ConfigService],
     }),
     FirstAidModule,
+    AuthModule,
+    UsersModule,
   ],
 })
 export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Post, Put, Query, Request, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Put,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { SignupDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,14 +1,20 @@
-import { Body, Controller, HttpCode, HttpStatus, Post, Put, Request, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, Put, Query, Request, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { SignupDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';
 import { ChangePasswordDto } from './dto/change-password.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { CheckEmailDto } from './dto/check-email.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
+
+  @Get('check-email')
+  checkEmail(@Query() query: CheckEmailDto) {
+    return this.authService.checkEmail(query.email);
+  }
 
   @Post('signup')
   async signup(@Body() dto: SignupDto) {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,48 @@
+import { Body, Controller, HttpCode, HttpStatus, Post, Put, Request, UseGuards } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { SignupDto } from './dto/signup.dto';
+import { LoginDto } from './dto/login.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('signup')
+  async signup(@Body() dto: SignupDto) {
+    await this.authService.signup(dto);
+    return null;
+  }
+
+  @Post('login')
+  @HttpCode(HttpStatus.OK)
+  async login(@Body() dto: LoginDto) {
+    return this.authService.login(dto.email, dto.password);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('logout')
+  @HttpCode(HttpStatus.OK)
+  async logout(@Request() req: { user: { id: number } }) {
+    await this.authService.logout(req.user.id);
+    return null;
+  }
+
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  async refresh(@Body() dto: RefreshTokenDto) {
+    return this.authService.refresh(dto.refreshToken);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Put('password')
+  async changePassword(
+    @Request() req: { user: { id: number } },
+    @Body() dto: ChangePasswordDto,
+  ) {
+    await this.authService.changePassword(req.user.id, dto);
+    return null;
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { UsersModule } from '../users/users.module';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './strategies/jwt.strategy';
+
+@Module({
+  imports: [
+    UsersModule,
+    PassportModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: (config.get<string>('JWT_EXPIRES_IN', '1h')) as never },
+      }),
+      inject: [ConfigService],
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+})
+export class AuthModule {}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -15,7 +15,9 @@ import { JwtStrategy } from './strategies/jwt.strategy';
       imports: [ConfigModule],
       useFactory: (config: ConfigService) => ({
         secret: config.get<string>('JWT_SECRET'),
-        signOptions: { expiresIn: (config.get<string>('JWT_EXPIRES_IN', '1h')) as never },
+        signOptions: {
+          expiresIn: config.get<string>('JWT_EXPIRES_IN', '1h') as never,
+        },
       }),
       inject: [ConfigService],
     }),

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -100,6 +100,11 @@ export class AuthService {
     return { accessToken };
   }
 
+  async checkEmail(email: string): Promise<{ available: boolean }> {
+    const exists = await this.usersService.existsByEmail(email);
+    return { available: !exists };
+  }
+
   async changePassword(userId: number, dto: ChangePasswordDto): Promise<void> {
     if (dto.newPassword !== dto.newPasswordConfirm) {
       throw new BadRequestException({

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,136 @@
+import {
+  BadRequestException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcrypt';
+import { UsersService } from '../users/users.service';
+import { SignupDto } from './dto/signup.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
+import { ErrorCode } from '../common/constants/error-codes';
+
+const SALT_ROUNDS = 12;
+const DUMMY_HASH = '$2b$12$invalidhashpadding00000000000000000000000000000000000000';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly jwtService: JwtService,
+    private readonly config: ConfigService,
+  ) {}
+
+  async signup(dto: SignupDto): Promise<void> {
+    if (dto.password !== dto.passwordConfirm) {
+      throw new BadRequestException({
+        message: '비밀번호가 일치하지 않습니다.',
+        errorCode: ErrorCode.VALIDATION_FAILED,
+      });
+    }
+
+    const hashedPassword = await bcrypt.hash(dto.password, SALT_ROUNDS);
+    await this.usersService.create({
+      email: dto.email,
+      name: dto.name,
+      password: hashedPassword,
+      birthDate: dto.birthDate,
+      countryCode: dto.countryCode,
+      phoneNumber: dto.phoneNumber,
+    });
+  }
+
+  async login(email: string, password: string) {
+    const user = await this.usersService.findByEmailWithPassword(email);
+
+    if (!user) {
+      await bcrypt.compare(password, DUMMY_HASH);
+      throw new UnauthorizedException({
+        message: '이메일 또는 비밀번호가 올바르지 않습니다.',
+        errorCode: ErrorCode.INVALID_CREDENTIALS,
+      });
+    }
+
+    const isValid = await bcrypt.compare(password, user.password);
+    if (!isValid) {
+      throw new UnauthorizedException({
+        message: '이메일 또는 비밀번호가 올바르지 않습니다.',
+        errorCode: ErrorCode.INVALID_CREDENTIALS,
+      });
+    }
+
+    const { accessToken, refreshToken } = this.generateTokens(user.id, user.email);
+    await this.usersService.updateRefreshToken(user.id, refreshToken);
+
+    return {
+      accessToken,
+      refreshToken,
+      user: { id: user.id, email: user.email, name: user.name },
+    };
+  }
+
+  async logout(userId: number): Promise<void> {
+    await this.usersService.updateRefreshToken(userId, null);
+  }
+
+  async refresh(refreshToken: string) {
+    let payload: { sub: number; email: string };
+
+    try {
+      payload = this.jwtService.verify<{ sub: number; email: string }>(refreshToken, {
+        secret: this.config.get<string>('JWT_REFRESH_SECRET'),
+      });
+    } catch {
+      throw new UnauthorizedException({
+        message: '유효하지 않은 리프레시 토큰입니다.',
+        errorCode: ErrorCode.UNAUTHORIZED,
+      });
+    }
+
+    const user = await this.usersService.findByIdWithRefreshToken(payload.sub);
+    if (!user || user.refreshToken !== refreshToken) {
+      throw new UnauthorizedException({
+        message: '유효하지 않은 리프레시 토큰입니다.',
+        errorCode: ErrorCode.UNAUTHORIZED,
+      });
+    }
+
+    const { accessToken } = this.generateTokens(user.id, user.email);
+    return { accessToken };
+  }
+
+  async changePassword(userId: number, dto: ChangePasswordDto): Promise<void> {
+    if (dto.newPassword !== dto.newPasswordConfirm) {
+      throw new BadRequestException({
+        message: '새 비밀번호가 일치하지 않습니다.',
+        errorCode: ErrorCode.VALIDATION_FAILED,
+      });
+    }
+
+    const user = await this.usersService.findByEmailWithPassword(
+      (await this.usersService.findById(userId))!.email,
+    );
+
+    const isValid = await bcrypt.compare(dto.currentPassword, user!.password);
+    if (!isValid) {
+      throw new UnauthorizedException({
+        message: '현재 비밀번호가 올바르지 않습니다.',
+        errorCode: ErrorCode.INVALID_CREDENTIALS,
+      });
+    }
+
+    const hashed = await bcrypt.hash(dto.newPassword, SALT_ROUNDS);
+    await this.usersService.updatePassword(userId, hashed);
+  }
+
+  private generateTokens(userId: number, email: string) {
+    const payload = { sub: userId, email };
+    const accessToken = this.jwtService.sign(payload);
+    const refreshToken = this.jwtService.sign(payload, {
+      secret: this.config.get<string>('JWT_REFRESH_SECRET'),
+      expiresIn: this.config.get<string>('JWT_REFRESH_EXPIRES_IN', '30d') as never,
+    });
+    return { accessToken, refreshToken };
+  }
+}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -12,7 +12,8 @@ import { ChangePasswordDto } from './dto/change-password.dto';
 import { ErrorCode } from '../common/constants/error-codes';
 
 const SALT_ROUNDS = 12;
-const DUMMY_HASH = '$2b$12$invalidhashpadding00000000000000000000000000000000000000';
+const DUMMY_HASH =
+  '$2b$12$invalidhashpadding00000000000000000000000000000000000000';
 
 @Injectable()
 export class AuthService {
@@ -60,7 +61,10 @@ export class AuthService {
       });
     }
 
-    const { accessToken, refreshToken } = this.generateTokens(user.id, user.email);
+    const { accessToken, refreshToken } = this.generateTokens(
+      user.id,
+      user.email,
+    );
     await this.usersService.updateRefreshToken(user.id, refreshToken);
 
     return {
@@ -78,9 +82,12 @@ export class AuthService {
     let payload: { sub: number; email: string };
 
     try {
-      payload = this.jwtService.verify<{ sub: number; email: string }>(refreshToken, {
-        secret: this.config.get<string>('JWT_REFRESH_SECRET'),
-      });
+      payload = this.jwtService.verify<{ sub: number; email: string }>(
+        refreshToken,
+        {
+          secret: this.config.get<string>('JWT_REFRESH_SECRET'),
+        },
+      );
     } catch {
       throw new UnauthorizedException({
         message: '유효하지 않은 리프레시 토큰입니다.',
@@ -134,7 +141,10 @@ export class AuthService {
     const accessToken = this.jwtService.sign(payload);
     const refreshToken = this.jwtService.sign(payload, {
       secret: this.config.get<string>('JWT_REFRESH_SECRET'),
-      expiresIn: this.config.get<string>('JWT_REFRESH_EXPIRES_IN', '30d') as never,
+      expiresIn: this.config.get<string>(
+        'JWT_REFRESH_EXPIRES_IN',
+        '30d',
+      ) as never,
     });
     return { accessToken, refreshToken };
   }

--- a/src/auth/dto/change-password.dto.ts
+++ b/src/auth/dto/change-password.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, Matches, MaxLength, MinLength } from 'class-validator';
+
+export class ChangePasswordDto {
+  @IsString()
+  @MinLength(1)
+  currentPassword: string;
+
+  @IsString()
+  @MinLength(8)
+  @MaxLength(64)
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])/, {
+    message: '비밀번호는 대소문자, 숫자, 특수문자(!@#$%^&*)를 각각 하나 이상 포함해야 합니다.',
+  })
+  newPassword: string;
+
+  @IsString()
+  newPasswordConfirm: string;
+}

--- a/src/auth/dto/change-password.dto.ts
+++ b/src/auth/dto/change-password.dto.ts
@@ -9,7 +9,8 @@ export class ChangePasswordDto {
   @MinLength(8)
   @MaxLength(64)
   @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])/, {
-    message: '비밀번호는 대소문자, 숫자, 특수문자(!@#$%^&*)를 각각 하나 이상 포함해야 합니다.',
+    message:
+      '비밀번호는 대소문자, 숫자, 특수문자(!@#$%^&*)를 각각 하나 이상 포함해야 합니다.',
   })
   newPassword: string;
 

--- a/src/auth/dto/check-email.dto.ts
+++ b/src/auth/dto/check-email.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator';
+
+export class CheckEmailDto {
+  @IsEmail()
+  email: string;
+}

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(1)
+  password: string;
+}

--- a/src/auth/dto/refresh-token.dto.ts
+++ b/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class RefreshTokenDto {
+  @IsString()
+  refreshToken: string;
+}

--- a/src/auth/dto/signup.dto.ts
+++ b/src/auth/dto/signup.dto.ts
@@ -1,0 +1,41 @@
+import {
+  IsDateString,
+  IsEmail,
+  IsString,
+  Matches,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class SignupDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  name: string;
+
+  @IsString()
+  @MinLength(8)
+  @MaxLength(64)
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])/, {
+    message: '비밀번호는 대소문자, 숫자, 특수문자(!@#$%^&*)를 각각 하나 이상 포함해야 합니다.',
+  })
+  password: string;
+
+  @IsString()
+  passwordConfirm: string;
+
+  @IsDateString()
+  birthDate: string;
+
+  @IsString()
+  @MinLength(2)
+  @MaxLength(10)
+  countryCode: string;
+
+  @IsString()
+  @Matches(/^\+?[1-9]\d{1,14}$/, { message: '올바른 전화번호 형식이 아닙니다.' })
+  phoneNumber: string;
+}

--- a/src/auth/dto/signup.dto.ts
+++ b/src/auth/dto/signup.dto.ts
@@ -20,7 +20,8 @@ export class SignupDto {
   @MinLength(8)
   @MaxLength(64)
   @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])/, {
-    message: '비밀번호는 대소문자, 숫자, 특수문자(!@#$%^&*)를 각각 하나 이상 포함해야 합니다.',
+    message:
+      '비밀번호는 대소문자, 숫자, 특수문자(!@#$%^&*)를 각각 하나 이상 포함해야 합니다.',
   })
   password: string;
 
@@ -36,6 +37,8 @@ export class SignupDto {
   countryCode: string;
 
   @IsString()
-  @Matches(/^\+?[1-9]\d{1,14}$/, { message: '올바른 전화번호 형식이 아닙니다.' })
+  @Matches(/^\+?[1-9]\d{1,14}$/, {
+    message: '올바른 전화번호 형식이 아닙니다.',
+  })
   phoneNumber: string;
 }

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -25,7 +25,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(payload: JwtPayload) {
     const user = await this.usersService.findById(payload.sub);
     if (!user) {
-      throw new UnauthorizedException({ message: '인증 정보가 유효하지 않습니다.', errorCode: 'UNAUTHORIZED' });
+      throw new UnauthorizedException({
+        message: '인증 정보가 유효하지 않습니다.',
+        errorCode: 'UNAUTHORIZED',
+      });
     }
     return { id: user.id, email: user.email, name: user.name };
   }

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,32 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { UsersService } from '../../users/users.service';
+
+interface JwtPayload {
+  sub: number;
+  email: string;
+}
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly usersService: UsersService,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: config.get<string>('JWT_SECRET') as string,
+    });
+  }
+
+  async validate(payload: JwtPayload) {
+    const user = await this.usersService.findById(payload.sub);
+    if (!user) {
+      throw new UnauthorizedException({ message: '인증 정보가 유효하지 않습니다.', errorCode: 'UNAUTHORIZED' });
+    }
+    return { id: user.id, email: user.email, name: user.name };
+  }
+}

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -29,7 +29,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
       if (typeof exceptionResponse === 'object' && exceptionResponse !== null) {
         const res = exceptionResponse as Record<string, unknown>;
         message = (res.message as string) ?? exception.message;
-        errorCode = (res.errorCode as ErrorCode) ?? this.statusToErrorCode(status);
+        errorCode =
+          (res.errorCode as ErrorCode) ?? this.statusToErrorCode(status);
 
         // ValidationPipe 에러는 message가 배열
         if (Array.isArray(res.message)) {
@@ -41,7 +42,10 @@ export class HttpExceptionFilter implements ExceptionFilter {
         errorCode = this.statusToErrorCode(status);
       }
     } else {
-      this.logger.error(`Unhandled exception on ${request.method} ${request.url}`, exception);
+      this.logger.error(
+        `Unhandled exception on ${request.method} ${request.url}`,
+        exception,
+      );
     }
 
     response.status(status).json({

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -38,7 +38,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
           errorCode = ErrorCode.VALIDATION_FAILED;
         }
       } else {
-        message = exceptionResponse as string;
+        message = exceptionResponse;
         errorCode = this.statusToErrorCode(status);
       }
     } else {
@@ -55,7 +55,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     });
   }
 
-  private statusToErrorCode(status: number): ErrorCode {
+  private statusToErrorCode(status: HttpStatus): ErrorCode {
     switch (status) {
       case HttpStatus.UNAUTHORIZED:
         return ErrorCode.UNAUTHORIZED;

--- a/src/common/interceptors/response.interceptor.ts
+++ b/src/common/interceptors/response.interceptor.ts
@@ -1,10 +1,18 @@
-import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 @Injectable()
 export class ResponseInterceptor<T> implements NestInterceptor<T, unknown> {
-  intercept(_context: ExecutionContext, next: CallHandler<T>): Observable<unknown> {
+  intercept(
+    _context: ExecutionContext,
+    next: CallHandler<T>,
+  ): Observable<unknown> {
     return next.handle().pipe(
       map((data) => ({
         message: '성공',

--- a/src/first-aid/dto/advice-request.dto.ts
+++ b/src/first-aid/dto/advice-request.dto.ts
@@ -1,4 +1,12 @@
-import { IsEnum, IsNumber, IsString, Max, MaxLength, Min, MinLength } from 'class-validator';
+import {
+  IsEnum,
+  IsNumber,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
 
 export enum SymptomType {
   BLEEDING = 'BLEEDING',

--- a/src/first-aid/first-aid.module.ts
+++ b/src/first-aid/first-aid.module.ts
@@ -7,6 +7,11 @@ import { OpenAiService } from './services/openai.service';
 
 @Module({
   controllers: [FirstAidController],
-  providers: [FirstAidService, GeocodingService, EmergencyContactService, OpenAiService],
+  providers: [
+    FirstAidService,
+    GeocodingService,
+    EmergencyContactService,
+    OpenAiService,
+  ],
 })
 export class FirstAidModule {}

--- a/src/first-aid/first-aid.service.ts
+++ b/src/first-aid/first-aid.service.ts
@@ -15,10 +15,8 @@ export class FirstAidService {
   async getAdvice(dto: AdviceRequestDto) {
     const { symptomType, symptomDetail, latitude, longitude } = dto;
 
-    const { countryCode, countryName } = await this.geocodingService.getCountryInfo(
-      latitude,
-      longitude,
-    );
+    const { countryCode, countryName } =
+      await this.geocodingService.getCountryInfo(latitude, longitude);
 
     const [emergencyContact, aiResult] = await Promise.all([
       Promise.resolve(this.emergencyContactService.getContacts(countryCode)),

--- a/src/first-aid/services/emergency-contact.service.ts
+++ b/src/first-aid/services/emergency-contact.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { EmergencyContact, EMERGENCY_CONTACTS } from '../constants/emergency-contacts';
+import {
+  EmergencyContact,
+  EMERGENCY_CONTACTS,
+} from '../constants/emergency-contacts';
 
 @Injectable()
 export class EmergencyContactService {

--- a/src/first-aid/services/geocoding.service.ts
+++ b/src/first-aid/services/geocoding.service.ts
@@ -10,7 +10,10 @@ interface GeocodingResult {
 export class GeocodingService {
   private readonly logger = new Logger(GeocodingService.name);
 
-  async getCountryInfo(latitude: number, longitude: number): Promise<GeocodingResult> {
+  async getCountryInfo(
+    latitude: number,
+    longitude: number,
+  ): Promise<GeocodingResult> {
     try {
       const { data } = await axios.get(
         'https://api.bigdatacloud.net/data/reverse-geocode-client',
@@ -25,7 +28,9 @@ export class GeocodingService {
 
       return { countryCode, countryName };
     } catch (error) {
-      this.logger.warn(`Geocoding 실패 (${latitude}, ${longitude}): ${(error as Error).message}`);
+      this.logger.warn(
+        `Geocoding 실패 (${latitude}, ${longitude}): ${(error as Error).message}`,
+      );
       return { countryCode: 'UNKNOWN', countryName: 'Unknown' };
     }
   }

--- a/src/first-aid/services/geocoding.service.ts
+++ b/src/first-aid/services/geocoding.service.ts
@@ -15,16 +15,16 @@ export class GeocodingService {
     longitude: number,
   ): Promise<GeocodingResult> {
     try {
-      const { data } = await axios.get(
-        'https://api.bigdatacloud.net/data/reverse-geocode-client',
-        {
-          params: { latitude, longitude, localityLanguage: 'en' },
-          timeout: 5000,
-        },
-      );
+      const { data } = await axios.get<{
+        countryCode?: string;
+        countryName?: string;
+      }>('https://api.bigdatacloud.net/data/reverse-geocode-client', {
+        params: { latitude, longitude, localityLanguage: 'en' },
+        timeout: 5000,
+      });
 
-      const countryCode = (data.countryCode as string | undefined) ?? 'UNKNOWN';
-      const countryName = (data.countryName as string | undefined) ?? 'Unknown';
+      const countryCode = data.countryCode ?? 'UNKNOWN';
+      const countryName = data.countryName ?? 'Unknown';
 
       return { countryCode, countryName };
     } catch (error) {

--- a/src/first-aid/services/openai.service.ts
+++ b/src/first-aid/services/openai.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
 import { SymptomType } from '../dto/advice-request.dto';
@@ -43,7 +47,9 @@ export class OpenAiService {
   private readonly client: OpenAI;
 
   constructor(private readonly config: ConfigService) {
-    this.client = new OpenAI({ apiKey: this.config.get<string>('OPENAI_API_KEY') });
+    this.client = new OpenAI({
+      apiKey: this.config.get<string>('OPENAI_API_KEY'),
+    });
   }
 
   async getAdvice(
@@ -70,7 +76,8 @@ export class OpenAiService {
     } catch (error) {
       this.logger.error(`OpenAI 호출 실패: ${(error as Error).message}`);
       throw new InternalServerErrorException({
-        message: 'AI 서비스에 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+        message:
+          'AI 서비스에 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
         errorCode: ErrorCode.AI_SERVICE_UNAVAILABLE,
       });
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,8 @@ async function bootstrap() {
   app.setGlobalPrefix('api');
 
   app.enableCors({
-    origin: process.env.NODE_ENV === 'production' ? process.env.ALLOWED_ORIGIN : '*',
+    origin:
+      process.env.NODE_ENV === 'production' ? process.env.ALLOWED_ORIGIN : '*',
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
     allowedHeaders: ['Content-Type', 'Authorization'],
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,4 +30,4 @@ async function bootstrap() {
   const port = process.env.PORT ?? 3000;
   await app.listen(port);
 }
-bootstrap();
+void bootstrap();

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,0 +1,42 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('users')
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index({ unique: true })
+  @Column({ type: 'varchar', length: 255 })
+  email: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  name: string;
+
+  @Column({ type: 'varchar', length: 255, select: false })
+  password: string;
+
+  @Column({ type: 'date' })
+  birthDate: string;
+
+  @Column({ type: 'varchar', length: 10 })
+  countryCode: string;
+
+  @Column({ type: 'varchar', length: 20 })
+  phoneNumber: string;
+
+  @Column({ type: 'text', nullable: true, select: false })
+  refreshToken: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { UsersService } from './users.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  providers: [UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -57,4 +57,8 @@ export class UsersService {
   async updatePassword(id: number, hashedPassword: string): Promise<void> {
     await this.usersRepository.update(id, { password: hashedPassword });
   }
+
+  async existsByEmail(email: string): Promise<boolean> {
+    return this.usersRepository.existsBy({ email });
+  }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -19,7 +19,9 @@ export class UsersService {
     countryCode: string;
     phoneNumber: string;
   }): Promise<User> {
-    const existing = await this.usersRepository.findOne({ where: { email: data.email } });
+    const existing = await this.usersRepository.findOne({
+      where: { email: data.email },
+    });
     if (existing) {
       throw new ConflictException({
         message: '이미 사용 중인 이메일입니다.',
@@ -50,7 +52,10 @@ export class UsersService {
     return this.usersRepository.findOne({ where: { id } });
   }
 
-  async updateRefreshToken(id: number, refreshToken: string | null): Promise<void> {
+  async updateRefreshToken(
+    id: number,
+    refreshToken: string | null,
+  ): Promise<void> {
     await this.usersRepository.update(id, { refreshToken });
   }
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,60 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from './entities/user.entity';
+import { ErrorCode } from '../common/constants/error-codes';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  async create(data: {
+    email: string;
+    name: string;
+    password: string;
+    birthDate: string;
+    countryCode: string;
+    phoneNumber: string;
+  }): Promise<User> {
+    const existing = await this.usersRepository.findOne({ where: { email: data.email } });
+    if (existing) {
+      throw new ConflictException({
+        message: '이미 사용 중인 이메일입니다.',
+        errorCode: ErrorCode.EMAIL_ALREADY_EXISTS,
+      });
+    }
+    const user = this.usersRepository.create(data);
+    return this.usersRepository.save(user);
+  }
+
+  async findByEmailWithPassword(email: string): Promise<User | null> {
+    return this.usersRepository
+      .createQueryBuilder('user')
+      .addSelect('user.password')
+      .where('user.email = :email', { email })
+      .getOne();
+  }
+
+  async findByIdWithRefreshToken(id: number): Promise<User | null> {
+    return this.usersRepository
+      .createQueryBuilder('user')
+      .addSelect('user.refreshToken')
+      .where('user.id = :id', { id })
+      .getOne();
+  }
+
+  async findById(id: number): Promise<User | null> {
+    return this.usersRepository.findOne({ where: { id } });
+  }
+
+  async updateRefreshToken(id: number, refreshToken: string | null): Promise<void> {
+    await this.usersRepository.update(id, { refreshToken });
+  }
+
+  async updatePassword(id: number, hashedPassword: string): Promise<void> {
+    await this.usersRepository.update(id, { password: hashedPassword });
+  }
+}


### PR DESCRIPTION
## 개요
JWT accessToken + refreshToken 기반 인증 API를 구현합니다.
로그아웃 시 DB의 refreshToken을 null로 무효화합니다.

## 엔드포인트
| Method | Path | Auth | 설명 |
|---|---|---|---|
| GET | /api/auth/check-email | 없음 | 이메일 중복 확인 |
| POST | /api/auth/signup | 없음 | 회원가입 (성공 message만 반환) |
| POST | /api/auth/login | 없음 | 로그인 (accessToken + refreshToken + user) |
| POST | /api/auth/logout | Bearer JWT | 로그아웃 (refreshToken 무효화) |
| POST | /api/auth/refresh | 없음 | 토큰 갱신 (새 accessToken 반환) |
| PUT | /api/auth/password | Bearer JWT | 비밀번호 변경 |

## 구현 내용

**엔티티**
- `User` — id(auto-increment), email, name, password, birthDate, countryCode, phoneNumber, refreshToken(select: false)

**보안**
- bcrypt cost=12 비밀번호 해싱
- 로그인 이메일 미존재 시에도 bcrypt 실행 (타이밍 공격 방지)
- accessToken / refreshToken 별도 secret 분리
- refreshToken DB 저장, 로그아웃 시 null 처리

## Closes
Closes #4