### PR TITLE
[FEAT] 유저 프로필 조회 및 수정 API (#6)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { FirstAidModule } from './first-aid/first-aid.module';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
+import { UserModule } from './user/user.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { UsersModule } from './users/users.module';
     FirstAidModule,
     AuthModule,
     UsersModule,
+    UserModule,
   ],
 })
 export class AppModule {}

--- a/src/user/dto/update-profile.dto.ts
+++ b/src/user/dto/update-profile.dto.ts
@@ -1,0 +1,22 @@
+import { IsDateString, IsString, Matches, MaxLength, MinLength } from 'class-validator';
+
+export class UpdateProfileDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  name: string;
+
+  @IsDateString()
+  birthDate: string;
+
+  @IsString()
+  @MinLength(2)
+  @MaxLength(10)
+  countryCode: string;
+
+  @IsString()
+  @Matches(/^\+?[1-9]\d{1,14}$/, {
+    message: '올바른 전화번호 형식이 아닙니다.',
+  })
+  phoneNumber: string;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,0 +1,23 @@
+import { Body, Controller, Get, Put, Request, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { UsersService } from '../users/users.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+@Controller('user')
+@UseGuards(JwtAuthGuard)
+export class UserController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get('profile')
+  async getProfile(@Request() req: { user: { id: number } }) {
+    return this.usersService.findById(req.user.id);
+  }
+
+  @Put('profile')
+  async updateProfile(
+    @Request() req: { user: { id: number } },
+    @Body() dto: UpdateProfileDto,
+  ) {
+    await this.usersService.updateProfile(req.user.id, dto);
+  }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UsersModule } from '../users/users.module';
+import { UserController } from './user.controller';
+
+@Module({
+  imports: [UsersModule],
+  controllers: [UserController],
+})
+export class UserModule {}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -7,6 +7,10 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+export enum Provider {
+  LOCAL = 'LOCAL',
+}
+
 @Entity('users')
 export class User {
   @PrimaryGeneratedColumn()
@@ -30,6 +34,12 @@ export class User {
 
   @Column({ type: 'varchar', length: 20 })
   phoneNumber: string;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  profileImageUrl: string | null;
+
+  @Column({ type: 'enum', enum: Provider, default: Provider.LOCAL })
+  provider: Provider;
 
   @Column({ type: 'text', nullable: true, select: false })
   refreshToken: string | null;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -66,4 +66,16 @@ export class UsersService {
   async existsByEmail(email: string): Promise<boolean> {
     return this.usersRepository.existsBy({ email });
   }
+
+  async updateProfile(
+    id: number,
+    data: {
+      name: string;
+      birthDate: string;
+      countryCode: string;
+      phoneNumber: string;
+    },
+  ): Promise<void> {
+    await this.usersRepository.update(id, data);
+  }
 }


### PR DESCRIPTION
## 개요
JWT 인증 기반 유저 프로필 조회 및 수정 API 구현

## 변경 사항

### User 엔티티
- `profileImageUrl` 컬럼 추가 (varchar(500), nullable)
- `provider` 컬럼 추가 (enum: LOCAL, default: LOCAL)

### 신규 엔드포인트
| Method | Path | 설명 |
|---|---|---|
| `GET` | `/api/user/profile` | 내 프로필 조회 |
| `PUT` | `/api/user/profile` | 프로필 수정 |

### GET /api/user/profile 응답
```json
{
  "message": "성공",
  "data": {
    "id": 1,
    "email": "test@example.com",
    "name": "홍길동",
    "birthDate": "1990-01-01",
    "countryCode": "KR",
    "phoneNumber": "+821012345678",
    "profileImageUrl": null,
    "provider": "LOCAL"
  }
}
```

### PUT /api/user/profile 요청 바디
```json
{
  "name": "string",
  "birthDate": "2026-04-23",
  "countryCode": "KR",
  "phoneNumber": "+821012345678"
}
```

Closes #6