### PR TITLE
[FEAT] Google Places Nearby Search 

### DIFF
--- a/src/auth/dto/signup.dto.ts
+++ b/src/auth/dto/signup.dto.ts
@@ -20,7 +20,8 @@ export class SignupDto {
   @MinLength(8)
   @MaxLength(64)
   @Matches(/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*])/, {
-    message: '비밀번호는 영문, 숫자, 특수문자(!@#$%^&*)를 각각 하나 이상 포함해야 합니다.',
+    message:
+      '비밀번호는 영문, 숫자, 특수문자(!@#$%^&*)를 각각 하나 이상 포함해야 합니다.',
   })
   password: string;
 

--- a/src/common/middleware/logger.middleware.ts
+++ b/src/common/middleware/logger.middleware.ts
@@ -11,7 +11,9 @@ export class LoggerMiddleware implements NestMiddleware {
 
     res.on('finish', () => {
       const ms = Date.now() - start;
-      this.logger.log(`${method} ${originalUrl} ${res.statusCode} ${ms}ms - ${ip}`);
+      this.logger.log(
+        `${method} ${originalUrl} ${res.statusCode} ${ms}ms - ${ip}`,
+      );
     });
 
     next();

--- a/src/location/dto/nearby-query.dto.ts
+++ b/src/location/dto/nearby-query.dto.ts
@@ -1,5 +1,12 @@
 import { Type } from 'class-transformer';
-import { IsEnum, IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
+import {
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 
 export enum FacilityType {
   HOSPITAL = 'hospital',

--- a/src/location/location.module.ts
+++ b/src/location/location.module.ts
@@ -2,11 +2,11 @@ import { Module } from '@nestjs/common';
 import { FirstAidModule } from '../first-aid/first-aid.module';
 import { LocationController } from './location.controller';
 import { LocationService } from './location.service';
-import { OverpassService } from './services/overpass.service';
+import { GooglePlacesService } from './services/google-places.service';
 
 @Module({
   imports: [FirstAidModule],
   controllers: [LocationController],
-  providers: [LocationService, OverpassService],
+  providers: [LocationService, GooglePlacesService],
 })
 export class LocationModule {}

--- a/src/location/location.service.ts
+++ b/src/location/location.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { GeocodingService } from '../first-aid/services/geocoding.service';
 import { EmergencyContactService } from '../first-aid/services/emergency-contact.service';
-import { OverpassService } from './services/overpass.service';
+import { GooglePlacesService } from './services/google-places.service';
 import { FacilityType } from './dto/nearby-query.dto';
 
 @Injectable()
@@ -9,7 +9,7 @@ export class LocationService {
   constructor(
     private readonly geocodingService: GeocodingService,
     private readonly emergencyContactService: EmergencyContactService,
-    private readonly overpassService: OverpassService,
+    private readonly googlePlacesService: GooglePlacesService,
   ) {}
 
   async identifyCountry(latitude: number, longitude: number) {
@@ -29,6 +29,6 @@ export class LocationService {
     type: FacilityType,
     language: string,
   ) {
-    return this.overpassService.getNearbyFacilities(latitude, longitude, radius, type, language);
+    return this.googlePlacesService.getNearbyFacilities(latitude, longitude, radius, type, language);
   }
 }

--- a/src/location/location.service.ts
+++ b/src/location/location.service.ts
@@ -13,11 +13,10 @@ export class LocationService {
   ) {}
 
   async identifyCountry(latitude: number, longitude: number) {
-    const { countryCode, countryName } = await this.geocodingService.getCountryInfo(
-      latitude,
-      longitude,
-    );
-    const emergencyContact = this.emergencyContactService.getContacts(countryCode);
+    const { countryCode, countryName } =
+      await this.geocodingService.getCountryInfo(latitude, longitude);
+    const emergencyContact =
+      this.emergencyContactService.getContacts(countryCode);
 
     return { countryCode, countryName, latitude, longitude, emergencyContact };
   }
@@ -29,6 +28,12 @@ export class LocationService {
     type: FacilityType,
     language: string,
   ) {
-    return this.googlePlacesService.getNearbyFacilities(latitude, longitude, radius, type, language);
+    return this.googlePlacesService.getNearbyFacilities(
+      latitude,
+      longitude,
+      radius,
+      type,
+      language,
+    );
   }
 }

--- a/src/location/services/google-places.service.ts
+++ b/src/location/services/google-places.service.ts
@@ -1,10 +1,15 @@
-import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import axios from 'axios';
 import { ErrorCode } from '../../common/constants/error-codes';
 import { FacilityType } from '../dto/nearby-query.dto';
 import { NearbyFacility } from './overpass.service';
 
-const GOOGLE_PLACES_URL = 'https://places.googleapis.com/v1/places:searchNearby';
+const GOOGLE_PLACES_URL =
+  'https://places.googleapis.com/v1/places:searchNearby';
 
 const FACILITY_TYPES: Record<FacilityType, string[]> = {
   [FacilityType.HOSPITAL]: ['hospital', 'doctor'],
@@ -26,7 +31,10 @@ const CACHE_TTL_MS = 2 * 60 * 60 * 1000;
 @Injectable()
 export class GooglePlacesService {
   private readonly logger = new Logger(GooglePlacesService.name);
-  private readonly cache = new Map<string, { data: NearbyFacility[]; expiresAt: number }>();
+  private readonly cache = new Map<
+    string,
+    { data: NearbyFacility[]; expiresAt: number }
+  >();
 
   async getNearbyFacilities(
     latitude: number,
@@ -50,7 +58,7 @@ export class GooglePlacesService {
     }
 
     try {
-      const response = await axios.post(
+      const response = await axios.post<{ places?: GooglePlace[] }>(
         GOOGLE_PLACES_URL,
         {
           includedTypes: FACILITY_TYPES[type],
@@ -72,7 +80,7 @@ export class GooglePlacesService {
         },
       );
 
-      const places: GooglePlace[] = response.data.places ?? [];
+      const places = response.data.places ?? [];
       const result: NearbyFacility[] = places
         .map((place) => ({
           name: place.displayName?.text ?? '',
@@ -82,7 +90,12 @@ export class GooglePlacesService {
           longitude: place.location.longitude,
           distance:
             Math.round(
-              this.haversine(latitude, longitude, place.location.latitude, place.location.longitude) * 10,
+              this.haversine(
+                latitude,
+                longitude,
+                place.location.latitude,
+                place.location.longitude,
+              ) * 10,
             ) / 10,
           openNow: place.regularOpeningHours?.openNow ?? null,
           openingHours: place.regularOpeningHours?.weekdayDescriptions ?? null,
@@ -90,7 +103,10 @@ export class GooglePlacesService {
         }))
         .sort((a, b) => a.distance - b.distance);
 
-      this.cache.set(cacheKey, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
+      this.cache.set(cacheKey, {
+        data: result,
+        expiresAt: Date.now() + CACHE_TTL_MS,
+      });
       return result;
     } catch (error) {
       this.logger.error(
@@ -104,7 +120,12 @@ export class GooglePlacesService {
     }
   }
 
-  private haversine(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  private haversine(
+    lat1: number,
+    lon1: number,
+    lat2: number,
+    lon2: number,
+  ): number {
     const R = 6371000;
     const toRad = (deg: number) => (deg * Math.PI) / 180;
     const dLat = toRad(lat2 - lat1);

--- a/src/location/services/google-places.service.ts
+++ b/src/location/services/google-places.service.ts
@@ -1,0 +1,126 @@
+import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
+import axios from 'axios';
+import { ErrorCode } from '../../common/constants/error-codes';
+import { FacilityType } from '../dto/nearby-query.dto';
+import { NearbyFacility } from './overpass.service';
+
+const GOOGLE_PLACES_URL = 'https://places.googleapis.com/v1/places:searchNearby';
+
+const FACILITY_TYPES: Record<FacilityType, string[]> = {
+  [FacilityType.HOSPITAL]: ['hospital', 'doctor'],
+  [FacilityType.PHARMACY]: ['pharmacy'],
+  [FacilityType.EMERGENCY]: ['hospital'],
+};
+
+const FIELD_MASK = [
+  'places.displayName',
+  'places.formattedAddress',
+  'places.nationalPhoneNumber',
+  'places.location',
+  'places.regularOpeningHours',
+  'places.websiteUri',
+].join(',');
+
+const CACHE_TTL_MS = 2 * 60 * 60 * 1000;
+
+@Injectable()
+export class GooglePlacesService {
+  private readonly logger = new Logger(GooglePlacesService.name);
+  private readonly cache = new Map<string, { data: NearbyFacility[]; expiresAt: number }>();
+
+  async getNearbyFacilities(
+    latitude: number,
+    longitude: number,
+    radius: number,
+    type: FacilityType,
+    language: string,
+  ): Promise<NearbyFacility[]> {
+    const cacheKey = `${type}:${latitude.toFixed(2)}:${longitude.toFixed(2)}:${radius}:${language}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && Date.now() < cached.expiresAt) {
+      return cached.data;
+    }
+
+    const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+    if (!apiKey) {
+      throw new ServiceUnavailableException({
+        message: '주변 의료시설 검색 서비스를 일시적으로 사용할 수 없습니다.',
+        errorCode: ErrorCode.EXTERNAL_SERVICE_UNAVAILABLE,
+      });
+    }
+
+    try {
+      const response = await axios.post(
+        GOOGLE_PLACES_URL,
+        {
+          includedTypes: FACILITY_TYPES[type],
+          maxResultCount: 20,
+          locationRestriction: {
+            circle: {
+              center: { latitude, longitude },
+              radius: Number(radius),
+            },
+          },
+          languageCode: language,
+        },
+        {
+          headers: {
+            'X-Goog-Api-Key': apiKey,
+            'X-Goog-FieldMask': FIELD_MASK,
+          },
+          timeout: 10000,
+        },
+      );
+
+      const places: GooglePlace[] = response.data.places ?? [];
+      const result: NearbyFacility[] = places
+        .map((place) => ({
+          name: place.displayName?.text ?? '',
+          address: place.formattedAddress ?? null,
+          phoneNumber: place.nationalPhoneNumber ?? null,
+          latitude: place.location.latitude,
+          longitude: place.location.longitude,
+          distance:
+            Math.round(
+              this.haversine(latitude, longitude, place.location.latitude, place.location.longitude) * 10,
+            ) / 10,
+          openNow: place.regularOpeningHours?.openNow ?? null,
+          openingHours: place.regularOpeningHours?.weekdayDescriptions ?? null,
+          websiteUrl: place.websiteUri ?? null,
+        }))
+        .sort((a, b) => a.distance - b.distance);
+
+      this.cache.set(cacheKey, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
+      return result;
+    } catch (error) {
+      this.logger.error(
+        'Google Places API 호출 실패',
+        error instanceof Error ? error.message : String(error),
+      );
+      throw new ServiceUnavailableException({
+        message: '주변 의료시설 검색 서비스를 일시적으로 사용할 수 없습니다.',
+        errorCode: ErrorCode.EXTERNAL_SERVICE_UNAVAILABLE,
+      });
+    }
+  }
+
+  private haversine(lat1: number, lon1: number, lat2: number, lon2: number): number {
+    const R = 6371000;
+    const toRad = (deg: number) => (deg * Math.PI) / 180;
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a =
+      Math.sin(dLat / 2) ** 2 +
+      Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  }
+}
+
+interface GooglePlace {
+  displayName?: { text: string };
+  formattedAddress?: string;
+  nationalPhoneNumber?: string;
+  location: { latitude: number; longitude: number };
+  regularOpeningHours?: { openNow: boolean; weekdayDescriptions: string[] };
+  websiteUri?: string;
+}

--- a/src/location/services/overpass.service.ts
+++ b/src/location/services/overpass.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import axios from 'axios';
 import { ErrorCode } from '../../common/constants/error-codes';
 import { FacilityType } from '../dto/nearby-query.dto';
@@ -35,13 +39,15 @@ const FACILITY_QUERIES: Record<FacilityType, string[]> = {
   [FacilityType.EMERGENCY]: ['["amenity"="hospital"]["emergency"="yes"]'],
 };
 
-
 const CACHE_TTL_MS = 30 * 60 * 1000;
 
 @Injectable()
 export class OverpassService {
   private readonly logger = new Logger(OverpassService.name);
-  private readonly cache = new Map<string, { data: NearbyFacility[]; expiresAt: number }>();
+  private readonly cache = new Map<
+    string,
+    { data: NearbyFacility[]; expiresAt: number }
+  >();
 
   async getNearbyFacilities(
     latitude: number,
@@ -57,7 +63,9 @@ export class OverpassService {
     }
 
     const filters = FACILITY_QUERIES[type];
-    const nodes = filters.map((f) => `node${f}(around:${radius},${latitude},${longitude});`).join('\n');
+    const nodes = filters
+      .map((f) => `node${f}(around:${radius},${latitude},${longitude});`)
+      .join('\n');
     const query = `[out:json][timeout:25];(${nodes});out body 100;`;
 
     let elements: OverpassElement[] = [];
@@ -65,21 +73,28 @@ export class OverpassService {
 
     for (const mirror of OVERPASS_MIRRORS) {
       try {
-        const response = await axios.get<{ elements: OverpassElement[] }>(mirror, {
-          params: { data: query },
-          timeout: 30000,
-        });
+        const response = await axios.get<{ elements: OverpassElement[] }>(
+          mirror,
+          {
+            params: { data: query },
+            timeout: 30000,
+          },
+        );
         elements = response.data.elements;
         break;
       } catch (error) {
         lastError = error;
-        this.logger.warn(`Overpass 미러 실패 (${mirror}) - code: ${axios.isAxiosError(error) ? error.code : 'unknown'}, msg: ${error instanceof Error ? error.message : String(error)}`);
+        this.logger.warn(
+          `Overpass 미러 실패 (${mirror}) - code: ${axios.isAxiosError(error) ? error.code : 'unknown'}, msg: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
     }
 
     if (!elements.length && lastError) {
       if (axios.isAxiosError(lastError)) {
-        this.logger.error(`Overpass API 전체 실패 - status: ${lastError.response?.status}, code: ${lastError.code}`);
+        this.logger.error(
+          `Overpass API 전체 실패 - status: ${lastError.response?.status}, code: ${lastError.code}`,
+        );
       }
       throw new ServiceUnavailableException({
         message: '주변 의료시설 검색 서비스를 일시적으로 사용할 수 없습니다.',
@@ -100,7 +115,8 @@ export class OverpassService {
           phoneNumber: tags.phone ?? tags['contact:phone'] ?? null,
           latitude: lat,
           longitude: lon,
-          distance: Math.round(this.haversine(latitude, longitude, lat, lon) * 10) / 10,
+          distance:
+            Math.round(this.haversine(latitude, longitude, lat, lon) * 10) / 10,
           openNow: this.isOpenNow(tags.opening_hours),
           openingHours: this.parseOpeningHours(tags.opening_hours),
           websiteUrl: tags.website ?? tags['contact:website'] ?? null,
@@ -108,7 +124,10 @@ export class OverpassService {
       })
       .sort((a, b) => a.distance - b.distance);
 
-    this.cache.set(cacheKey, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
+    this.cache.set(cacheKey, {
+      data: result,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    });
     return result;
   }
 
@@ -124,7 +143,12 @@ export class OverpassService {
     return parts.length > 0 ? parts.join(' ') : (tags['addr:full'] ?? null);
   }
 
-  private haversine(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  private haversine(
+    lat1: number,
+    lon1: number,
+    lat2: number,
+    lon2: number,
+  ): number {
     const R = 6371000;
     const toRad = (deg: number) => (deg * Math.PI) / 180;
     const dLat = toRad(lat2 - lat1);

--- a/src/user/dto/update-profile.dto.ts
+++ b/src/user/dto/update-profile.dto.ts
@@ -1,4 +1,10 @@
-import { IsDateString, IsString, Matches, MaxLength, MinLength } from 'class-validator';
+import {
+  IsDateString,
+  IsString,
+  Matches,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class UpdateProfileDto {
   @IsString()


### PR DESCRIPTION
## Summary

- Overpass API(무료 커뮤니티 서비스)를 Google Places Nearby Search API로 교체
- Overpass는 rate limit, ETIMEDOUT, 응답 지연 등 프로덕션 환경에서 불안정한 문제가 있었음
- Google Places는 안정적이고 빠른 응답, 더 정확한 의료시설 데이터 제공

## Changes

- `google-places.service.ts` 신규 생성 — POST 방식, 2시간 인메모리 캐시 포함
- `location.module.ts` — OverpassService → GooglePlacesService 교체
- `location.service.ts` — 의존성 교체
- 기존 `overpass.service.ts`는 `NearbyFacility` 인터페이스 참조를 위해 유지

## 환경 변수 추가 필요

EC2 `.env`에 아래 키 추가 필요:
```
GOOGLE_PLACES_API_KEY=your_api_key_here
```

Google Cloud Console에서 Places API(New) 활성화 후 발급

## API 변경사항

| 항목 | 이전 (Overpass) | 이후 (Google Places) |
|------|----------------|----------------------|
| 방식 | GET (Overpass QL) | POST (JSON) |
| 최대 결과 수 | 100개 | 20개 |
| 캐시 TTL | 30분 | 2시간 |
| 안정성 | 불안정 (rate limit) | 안정적 |
| 비용 | 무료 | 월 11,250건 무료 |

## Test plan

- [ ] EC2 `.env`에 `GOOGLE_PLACES_API_KEY` 추가
- [ ] `GET /api/location/nearby?latitude=37.5665&longitude=126.978&type=hospital&radius=1000&language=en` 응답 확인
- [ ] `type=pharmacy`, `type=emergency` 동작 확인
- [ ] 동일 조건 재요청 시 캐시 응답 확인 (빠른 응답)