### PR TITLE
[REFACTOR] 회원가입 race condition 및 changePassword 이중 쿼리 개선

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -120,9 +120,7 @@ export class AuthService {
       });
     }
 
-    const user = await this.usersService.findByEmailWithPassword(
-      (await this.usersService.findById(userId))!.email,
-    );
+    const user = await this.usersService.findByIdWithPassword(userId);
 
     const isValid = await bcrypt.compare(dto.currentPassword, user!.password);
     if (!isValid) {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,6 +1,6 @@
 import { ConflictException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import { ErrorCode } from '../common/constants/error-codes';
 
@@ -19,17 +19,21 @@ export class UsersService {
     countryCode: string;
     phoneNumber: string;
   }): Promise<User> {
-    const existing = await this.usersRepository.findOne({
-      where: { email: data.email },
-    });
-    if (existing) {
-      throw new ConflictException({
-        message: '이미 사용 중인 이메일입니다.',
-        errorCode: ErrorCode.EMAIL_ALREADY_EXISTS,
-      });
-    }
     const user = this.usersRepository.create(data);
-    return this.usersRepository.save(user);
+    try {
+      return await this.usersRepository.save(user);
+    } catch (e) {
+      if (
+        e instanceof QueryFailedError &&
+        (e as QueryFailedError & { code: string }).code === 'ER_DUP_ENTRY'
+      ) {
+        throw new ConflictException({
+          message: '이미 사용 중인 이메일입니다.',
+          errorCode: ErrorCode.EMAIL_ALREADY_EXISTS,
+        });
+      }
+      throw e;
+    }
   }
 
   async findByEmailWithPassword(email: string): Promise<User | null> {
@@ -44,6 +48,14 @@ export class UsersService {
     return this.usersRepository
       .createQueryBuilder('user')
       .addSelect('user.refreshToken')
+      .where('user.id = :id', { id })
+      .getOne();
+  }
+
+  async findByIdWithPassword(id: number): Promise<User | null> {
+    return this.usersRepository
+      .createQueryBuilder('user')
+      .addSelect('user.password')
       .where('user.id = :id', { id })
       .getOne();
   }


### PR DESCRIPTION
## 구현 내용

- **Race condition 수정** (`UsersService.create`): `findOne` → `save` 패턴은 원자적이지 않아 동시 요청 시 DB unique constraint 위반이 500으로 터지는 문제 → `save` 실패 시 `ER_DUP_ENTRY`를 잡아 409 `ConflictException`으로 변환
- **이중 쿼리 제거** (`AuthService.changePassword`): `findById` + `findByEmailWithPassword` 2번 → `findByIdWithPassword` 1번으로 통합
- **`findByIdWithPassword` 메서드 추가** (`UsersService`): id로 password 포함 조회

## 주요 파일

- `src/users/users.service.ts`
- `src/auth/auth.service.ts`

## 테스트 방법

```bash
# 동시 회원가입 — 409 응답 확인
curl -X POST http://localhost:3000/api/auth/signup \
  -H "Content-Type: application/json" \
  -d '{"email":"test@test.com","password":"pass1234!","passwordConfirm":"pass1234!","name":"테스트","birthDate":"1990-01-01","countryCode":"KR","phoneNumber":"01012345678"}'

# 비밀번호 변경 — 쿼리 1번으로 동작 확인
curl -X PATCH http://localhost:3000/api/auth/password \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"currentPassword":"pass1234!","newPassword":"new1234!","newPasswordConfirm":"new1234!"}'
```