### PR TITLE
[FEAT] Google Places API 연동 및 Swagger 문서화

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.4.1",
     "@nestjs/typeorm": "^11.0.1",
     "axios": "^1.15.2",
     "bcrypt": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+      '@nestjs/swagger':
+        specifier: ^11.4.1
+        version: 11.4.1(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^11.0.1
         version: 11.0.1(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(mysql2@3.22.2(@types/node@24.12.2))(ts-node@10.9.2(@types/node@24.12.2)(typescript@5.9.3)))
@@ -668,6 +671,9 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@microsoft/tsdoc@0.16.0':
+    resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -726,6 +732,19 @@ packages:
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
 
+  '@nestjs/mapped-types@2.1.1':
+    resolution: {integrity: sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      class-transformer: ^0.4.0 || ^0.5.0
+      class-validator: ^0.13.0 || ^0.14.0 || ^0.15.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
   '@nestjs/passport@11.0.5':
     resolution: {integrity: sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==}
     peerDependencies:
@@ -745,6 +764,23 @@ packages:
       typescript: '>=4.8.2'
     peerDependenciesMeta:
       prettier:
+        optional: true
+
+  '@nestjs/swagger@11.4.1':
+    resolution: {integrity: sha512-GuGzs8F1Cb3n+eEarmOqB4nt2ai+x4XGOYUXNYplOtDeB59DaFY5E16bsHsBWXiWgD1ywbyKQ5OVv02bQtB1Dw==}
+    peerDependencies:
+      '@fastify/static': ^8.0.0 || ^9.0.0
+      '@nestjs/common': ^11.0.1
+      '@nestjs/core': ^11.0.1
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
         optional: true
 
   '@nestjs/testing@11.1.19':
@@ -788,6 +824,9 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
@@ -2947,6 +2986,9 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  swagger-ui-dist@5.32.4:
+    resolution: {integrity: sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==}
+
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
@@ -4000,6 +4042,8 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@microsoft/tsdoc@0.16.0': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -4077,6 +4121,14 @@ snapshots:
       '@types/jsonwebtoken': 9.0.10
       jsonwebtoken: 9.0.3
 
+  '@nestjs/mapped-types@2.1.1(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.15.1
+
   '@nestjs/passport@11.0.5(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)':
     dependencies:
       '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -4106,6 +4158,21 @@ snapshots:
       prettier: 3.8.3
     transitivePeerDependencies:
       - chokidar
+
+  '@nestjs/swagger@11.4.1(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
+      js-yaml: 4.1.1
+      lodash: 4.18.1
+      path-to-regexp: 8.4.2
+      reflect-metadata: 0.2.2
+      swagger-ui-dist: 5.32.4
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.15.1
 
   '@nestjs/testing@11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@11.1.19)':
     dependencies:
@@ -4137,6 +4204,8 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.2.9': {}
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sinclair/typebox@0.34.49': {}
 
@@ -6497,6 +6566,10 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+
+  swagger-ui-dist@5.32.4:
+    dependencies:
+      '@scarf/scarf': 1.4.0
 
   symbol-observable@4.0.0: {}
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -10,6 +10,12 @@ import {
   Request,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { SignupDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';
@@ -18,27 +24,59 @@ import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { CheckEmailDto } from './dto/check-email.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  @ApiOperation({ summary: '이메일 중복 확인' })
+  @ApiOkResponse({
+    description: '사용 가능 여부',
+    schema: {
+      example: { message: '성공', data: { available: true } },
+    },
+  })
   @Get('check-email')
   checkEmail(@Query() query: CheckEmailDto) {
     return this.authService.checkEmail(query.email);
   }
 
+  @ApiOperation({ summary: '회원가입' })
+  @ApiOkResponse({
+    description: '회원가입 성공',
+    schema: { example: { message: '성공', data: null } },
+  })
   @Post('signup')
   async signup(@Body() dto: SignupDto) {
     await this.authService.signup(dto);
     return null;
   }
 
+  @ApiOperation({ summary: '로그인' })
+  @ApiOkResponse({
+    description: 'Access/Refresh 토큰 발급',
+    schema: {
+      example: {
+        message: '성공',
+        data: {
+          accessToken: 'eyJhbGci...',
+          refreshToken: 'eyJhbGci...',
+        },
+      },
+    },
+  })
   @Post('login')
   @HttpCode(HttpStatus.OK)
   async login(@Body() dto: LoginDto) {
     return this.authService.login(dto.email, dto.password);
   }
 
+  @ApiOperation({ summary: '로그아웃 (JWT 필요)' })
+  @ApiBearerAuth('access-token')
+  @ApiOkResponse({
+    description: '로그아웃 성공',
+    schema: { example: { message: '성공', data: null } },
+  })
   @UseGuards(JwtAuthGuard)
   @Post('logout')
   @HttpCode(HttpStatus.OK)
@@ -47,12 +85,31 @@ export class AuthController {
     return null;
   }
 
+  @ApiOperation({ summary: 'Access Token 재발급' })
+  @ApiOkResponse({
+    description: '새 Access/Refresh 토큰 발급',
+    schema: {
+      example: {
+        message: '성공',
+        data: {
+          accessToken: 'eyJhbGci...',
+          refreshToken: 'eyJhbGci...',
+        },
+      },
+    },
+  })
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
   async refresh(@Body() dto: RefreshTokenDto) {
     return this.authService.refresh(dto.refreshToken);
   }
 
+  @ApiOperation({ summary: '비밀번호 변경 (JWT 필요)' })
+  @ApiBearerAuth('access-token')
+  @ApiOkResponse({
+    description: '비밀번호 변경 성공',
+    schema: { example: { message: '성공', data: null } },
+  })
   @UseGuards(JwtAuthGuard)
   @Put('password')
   async changePassword(

--- a/src/auth/dto/change-password.dto.ts
+++ b/src/auth/dto/change-password.dto.ts
@@ -1,10 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsString, Matches, MaxLength, MinLength } from 'class-validator';
 
 export class ChangePasswordDto {
+  @ApiProperty({ example: 'OldPass1!', description: '현재 비밀번호' })
   @IsString()
   @MinLength(1)
   currentPassword: string;
 
+  @ApiProperty({
+    example: 'NewPass1!',
+    description:
+      '새 비밀번호 — 대소문자·숫자·특수문자(!@#$%^&*) 각 1자 이상, 8~64자',
+  })
   @IsString()
   @MinLength(8)
   @MaxLength(64)
@@ -14,6 +21,7 @@ export class ChangePasswordDto {
   })
   newPassword: string;
 
+  @ApiProperty({ example: 'NewPass1!', description: '새 비밀번호 확인' })
   @IsString()
   newPasswordConfirm: string;
 }

--- a/src/auth/dto/check-email.dto.ts
+++ b/src/auth/dto/check-email.dto.ts
@@ -1,6 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail } from 'class-validator';
 
 export class CheckEmailDto {
+  @ApiProperty({
+    example: 'user@example.com',
+    description: '중복 확인할 이메일',
+  })
   @IsEmail()
   email: string;
 }

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,9 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsString, MinLength } from 'class-validator';
 
 export class LoginDto {
+  @ApiProperty({ example: 'user@example.com', description: '이메일 주소' })
   @IsEmail()
   email: string;
 
+  @ApiProperty({ example: 'Pass1234!', description: '비밀번호' })
   @IsString()
   @MinLength(1)
   password: string;

--- a/src/auth/dto/refresh-token.dto.ts
+++ b/src/auth/dto/refresh-token.dto.ts
@@ -1,6 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
 
 export class RefreshTokenDto {
+  @ApiProperty({ example: 'eyJhbGci...', description: 'Refresh Token' })
   @IsString()
   refreshToken: string;
 }

--- a/src/auth/dto/signup.dto.ts
+++ b/src/auth/dto/signup.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsDateString,
   IsEmail,
@@ -8,14 +9,20 @@ import {
 } from 'class-validator';
 
 export class SignupDto {
+  @ApiProperty({ example: 'user@example.com', description: '이메일 주소' })
   @IsEmail()
   email: string;
 
+  @ApiProperty({ example: '홍길동', description: '이름 (1~100자)' })
   @IsString()
   @MinLength(1)
   @MaxLength(100)
   name: string;
 
+  @ApiProperty({
+    example: 'Pass1234!',
+    description: '비밀번호 — 영문·숫자·특수문자(!@#$%^&*) 각 1자 이상, 8~64자',
+  })
   @IsString()
   @MinLength(8)
   @MaxLength(64)
@@ -25,17 +32,27 @@ export class SignupDto {
   })
   password: string;
 
+  @ApiProperty({ example: 'Pass1234!', description: '비밀번호 확인' })
   @IsString()
   passwordConfirm: string;
 
+  @ApiProperty({
+    example: '2000-01-01',
+    description: '생년월일 (ISO 8601, YYYY-MM-DD)',
+  })
   @IsDateString()
   birthDate: string;
 
+  @ApiProperty({ example: 'KR', description: '국가 코드 (ISO 3166-1 alpha-2)' })
   @IsString()
   @MinLength(2)
   @MaxLength(10)
   countryCode: string;
 
+  @ApiProperty({
+    example: '+821012345678',
+    description: '전화번호 (E.164 형식)',
+  })
   @IsString()
   @Matches(/^\+?[1-9]\d{1,14}$/, {
     message: '올바른 전화번호 형식이 아닙니다.',

--- a/src/first-aid/dto/advice-request.dto.ts
+++ b/src/first-aid/dto/advice-request.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsEnum,
   IsNumber,
@@ -23,19 +24,32 @@ export enum SymptomType {
 }
 
 export class AdviceRequestDto {
+  @ApiProperty({
+    enum: SymptomType,
+    example: SymptomType.BLEEDING,
+    description: '증상 유형',
+  })
   @IsEnum(SymptomType)
   symptomType: SymptomType;
 
+  @ApiProperty({
+    example: '오른쪽 손목에서 출혈이 심하게 발생하고 있습니다.',
+    description: '증상 상세 설명 (10~2000자)',
+    minLength: 10,
+    maxLength: 2000,
+  })
   @IsString()
   @MinLength(10)
   @MaxLength(2000)
   symptomDetail: string;
 
+  @ApiProperty({ example: 37.5665, description: '위도 (-90 ~ 90)' })
   @IsNumber()
   @Min(-90)
   @Max(90)
   latitude: number;
 
+  @ApiProperty({ example: 126.978, description: '경도 (-180 ~ 180)' })
   @IsNumber()
   @Min(-180)
   @Max(180)

--- a/src/first-aid/first-aid.controller.ts
+++ b/src/first-aid/first-aid.controller.ts
@@ -1,11 +1,37 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { FirstAidService } from './first-aid.service';
 import { AdviceRequestDto } from './dto/advice-request.dto';
 
+@ApiTags('First Aid')
 @Controller('first-aid')
 export class FirstAidController {
   constructor(private readonly firstAidService: FirstAidService) {}
 
+  @ApiOperation({ summary: '응급처치 AI 조언 요청 (인증 불필요)' })
+  @ApiOkResponse({
+    description: 'AI 응급처치 조언 및 현지 응급연락처',
+    schema: {
+      example: {
+        message: '성공',
+        data: {
+          content: '출혈 부위를 깨끗한 천으로 압박하세요...',
+          summary: '직접 압박으로 출혈을 멈추세요.',
+          recommendedAction: '119에 즉시 신고하세요.',
+          identificationResponse: {
+            countryCode: 'KR',
+            countryName: 'South Korea',
+            latitude: 37.5665,
+            longitude: 126.9780,
+            emergencyContact: { police: '112', fire: '119', ambulance: '119' },
+          },
+          disclaimer: '본 정보는 참고용이며 전문 의료 조언을 대체하지 않습니다.',
+          confidence: 0.92,
+          blogLinks: ['https://example.com/first-aid-bleeding'],
+        },
+      },
+    },
+  })
   @Post('advice')
   getAdvice(@Body() dto: AdviceRequestDto) {
     return this.firstAidService.getAdvice(dto);

--- a/src/location/dto/identify-country.dto.ts
+++ b/src/location/dto/identify-country.dto.ts
@@ -1,11 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, Max, Min } from 'class-validator';
 
 export class IdentifyCountryDto {
+  @ApiProperty({ example: 37.5665, description: '위도 (-90 ~ 90)' })
   @IsNumber()
   @Min(-90)
   @Max(90)
   latitude: number;
 
+  @ApiProperty({ example: 126.978, description: '경도 (-180 ~ 180)' })
   @IsNumber()
   @Min(-180)
   @Max(180)

--- a/src/location/dto/nearby-query.dto.ts
+++ b/src/location/dto/nearby-query.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsEnum,
@@ -15,18 +16,25 @@ export enum FacilityType {
 }
 
 export class NearbyQueryDto {
+  @ApiProperty({ example: 37.5665, description: '위도 (-90 ~ 90)' })
   @Type(() => Number)
   @IsNumber()
   @Min(-90)
   @Max(90)
   latitude!: number;
 
+  @ApiProperty({ example: 126.978, description: '경도 (-180 ~ 180)' })
   @Type(() => Number)
   @IsNumber()
   @Min(-180)
   @Max(180)
   longitude!: number;
 
+  @ApiPropertyOptional({
+    example: 5000,
+    description: '검색 반경 (미터, 500~50000)',
+    default: 5000,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
@@ -34,10 +42,21 @@ export class NearbyQueryDto {
   @Max(50000)
   radius: number = 5000;
 
+  @ApiPropertyOptional({
+    enum: FacilityType,
+    example: FacilityType.HOSPITAL,
+    description: '시설 유형',
+    default: FacilityType.HOSPITAL,
+  })
   @IsOptional()
   @IsEnum(FacilityType)
   type: FacilityType = FacilityType.HOSPITAL;
 
+  @ApiPropertyOptional({
+    example: 'ko',
+    description: '응답 언어 코드 (BCP 47)',
+    default: 'en',
+  })
   @IsOptional()
   @IsString()
   language: string = 'en';

--- a/src/location/location.controller.ts
+++ b/src/location/location.controller.ts
@@ -1,17 +1,49 @@
 import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { LocationService } from './location.service';
 import { IdentifyCountryDto } from './dto/identify-country.dto';
 import { NearbyQueryDto } from './dto/nearby-query.dto';
 
+@ApiTags('Location')
 @Controller('location')
 export class LocationController {
   constructor(private readonly locationService: LocationService) {}
 
+  @ApiOperation({ summary: '좌표로 국가 식별' })
+  @ApiOkResponse({
+    description: '국가 코드 및 이름',
+    schema: {
+      example: {
+        message: '성공',
+        data: { countryCode: 'KR', countryName: 'South Korea' },
+      },
+    },
+  })
   @Post('identify-country')
   async identifyCountry(@Body() dto: IdentifyCountryDto) {
     return this.locationService.identifyCountry(dto.latitude, dto.longitude);
   }
 
+  @ApiOperation({ summary: '주변 의료시설 검색 (Google Places)' })
+  @ApiOkResponse({
+    description: '주변 시설 목록',
+    schema: {
+      example: {
+        message: '성공',
+        data: [
+          {
+            placeId: 'ChIJN1t_tDeuEmsRUsoyG83frY4',
+            name: '서울대학교병원',
+            address: '서울특별시 종로구 대학로 101',
+            location: { lat: 37.58, lng: 126.99 },
+            openNow: true,
+            rating: 4.2,
+            types: ['hospital'],
+          },
+        ],
+      },
+    },
+  })
   @Get('nearby')
   async getNearby(@Query() query: NearbyQueryDto) {
     return this.locationService.getNearbyFacilities(

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ dns.setDefaultResultOrder('ipv4first');
 
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
@@ -29,6 +30,21 @@ async function bootstrap() {
 
   app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalInterceptors(new ResponseInterceptor());
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('VitalTrip API')
+    .setDescription('VitalTrip 백엔드 API 문서')
+    .setVersion('1.0')
+    .addBearerAuth(
+      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+      'access-token',
+    )
+    .build();
+
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('docs', app, document, {
+    swaggerOptions: { persistAuthorization: true },
+  });
 
   const port = process.env.PORT ?? 3000;
   await app.listen(port);

--- a/src/user/dto/update-profile.dto.ts
+++ b/src/user/dto/update-profile.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsDateString,
   IsString,
@@ -7,19 +8,29 @@ import {
 } from 'class-validator';
 
 export class UpdateProfileDto {
+  @ApiProperty({ example: '홍길동', description: '이름 (1~100자)' })
   @IsString()
   @MinLength(1)
   @MaxLength(100)
   name: string;
 
+  @ApiProperty({
+    example: '2000-01-01',
+    description: '생년월일 (ISO 8601, YYYY-MM-DD)',
+  })
   @IsDateString()
   birthDate: string;
 
+  @ApiProperty({ example: 'KR', description: '국가 코드 (ISO 3166-1 alpha-2)' })
   @IsString()
   @MinLength(2)
   @MaxLength(10)
   countryCode: string;
 
+  @ApiProperty({
+    example: '+821012345678',
+    description: '전화번호 (E.164 형식)',
+  })
   @IsString()
   @Matches(/^\+?[1-9]\d{1,14}$/, {
     message: '올바른 전화번호 형식이 아닙니다.',

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,18 +1,48 @@
 import { Body, Controller, Get, Put, Request, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UsersService } from '../users/users.service';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 
+@ApiTags('User')
+@ApiBearerAuth('access-token')
 @Controller('user')
 @UseGuards(JwtAuthGuard)
 export class UserController {
   constructor(private readonly usersService: UsersService) {}
 
+  @ApiOperation({ summary: '내 프로필 조회 (JWT 필요)' })
+  @ApiOkResponse({
+    description: '사용자 프로필 정보',
+    schema: {
+      example: {
+        message: '성공',
+        data: {
+          id: 1,
+          email: 'user@example.com',
+          name: '홍길동',
+          birthDate: '2000-01-01',
+          countryCode: 'KR',
+          phoneNumber: '+821012345678',
+        },
+      },
+    },
+  })
   @Get('profile')
   async getProfile(@Request() req: { user: { id: number } }) {
     return this.usersService.findById(req.user.id);
   }
 
+  @ApiOperation({ summary: '프로필 수정 (JWT 필요)' })
+  @ApiOkResponse({
+    description: '수정 성공',
+    schema: { example: { message: '성공', data: null } },
+  })
   @Put('profile')
   async updateProfile(
     @Request() req: { user: { id: number } },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
     "strictBindCallApply": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "strictPropertyInitialization": false
   }
 }


### PR DESCRIPTION
## 구현 내용

- **Google Places Nearby Search API 연동**
  - Overpass API를 Google Places API로 교체 (안정성 및 응답 품질 향상)
  - `hospital` / `pharmacy` / `emergency` 시설 유형별 검색 지원
  - 반경, 언어, 시설 유형 쿼리 파라미터 지원 (기본값: 반경 5000m, 언어 en, 타입 hospital)
  - Google Places 응답 타입 명시로 ESLint 에러 해결

- **Swagger UI 추가 (`/docs`)**
  - `@nestjs/swagger` 설치 및 `SwaggerModule` 설정
  - JWT Bearer 인증 버튼 및 `persistAuthorization` 적용
  - 모든 DTO에 `@ApiProperty` / `@ApiPropertyOptional` 추가 (example, description)
  - 모든 컨트롤러에 `@ApiTags`, `@ApiOperation`, `@ApiOkResponse` 추가
  - 실제 응답 예시 (`{ message, data }` 래핑 포맷) 문서화

## 주요 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `src/main.ts` | SwaggerModule 설정 |
| `src/location/services/google-places.service.ts` | Google Places 서비스 신규 추가 |
| `src/location/location.service.ts` | Google Places 연동으로 교체 |
| `src/auth/auth.controller.ts` | Swagger 데코레이터 추가 |
| `src/first-aid/first-aid.controller.ts` | Swagger 데코레이터 추가 |
| `src/location/location.controller.ts` | Swagger 데코레이터 추가 |
| `src/user/user.controller.ts` | Swagger 데코레이터 추가 |
| `src/*/dto/*.ts` | 전체 DTO ApiProperty 추가 |

## 테스트 방법

**Swagger UI 접속**
```
http://localhost:3000/docs
```

**주변 병원 검색**
```bash
curl "http://localhost:3000/api/location/nearby?latitude=37.5665&longitude=126.9780&type=hospital&radius=3000&language=ko"
```

**응급처치 조언**
```bash
curl -X POST http://localhost:3000/api/first-aid/advice \
  -H "Content-Type: application/json" \
  -d '{"symptomType":"BLEEDING","symptomDetail":"오른쪽 손목에서 출혈이 심하게 발생하고 있습니다.","latitude":37.5665,"longitude":126.9780}'
```