### PR TITLE
[REFACTOR] 인증 정합성 및 데이터 일관성 결함 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - name: Get pnpm store path
         id: pnpm-cache

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -184,13 +184,19 @@ export class AuthController {
         errorCode: ErrorCode.UNAUTHORIZED,
       });
     }
-    const accessToken = await this.authService.adminRefresh(refreshToken);
+    const tokens = await this.authService.adminRefresh(refreshToken);
     const isProduction = this.config.get<string>('NODE_ENV') === 'production';
-    res.cookie('adminAccessToken', accessToken, {
+    res.cookie('adminAccessToken', tokens.accessToken, {
       httpOnly: true,
       secure: isProduction,
       sameSite: 'strict',
       maxAge: 60 * 60 * 1000,
+    });
+    res.cookie('adminRefreshToken', tokens.refreshToken, {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'strict',
+      maxAge: 30 * 24 * 60 * 60 * 1000,
     });
     return null;
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -123,7 +123,10 @@ export class AuthService {
     }
 
     const user = await this.usersService.findByIdWithRefreshToken(payload.sub);
-    if (!user || user.refreshToken !== refreshToken) {
+    const tokenValid = user?.refreshToken
+      ? await bcrypt.compare(refreshToken, user.refreshToken)
+      : false;
+    if (!user || !tokenValid) {
       throw new UnauthorizedException({
         message: '유효하지 않은 리프레시 토큰입니다.',
         errorCode: ErrorCode.UNAUTHORIZED,
@@ -288,7 +291,10 @@ export class AuthService {
     }
 
     const user = await this.usersService.findByIdWithRefreshToken(payload.sub);
-    if (!user || user.refreshToken !== refreshToken) {
+    const tokenValid = user?.refreshToken
+      ? await bcrypt.compare(refreshToken, user.refreshToken)
+      : false;
+    if (!user || !tokenValid) {
       throw new UnauthorizedException({
         message: '유효하지 않은 리프레시 토큰입니다.',
         errorCode: ErrorCode.UNAUTHORIZED,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -130,8 +130,9 @@ export class AuthService {
       });
     }
 
-    const { accessToken } = this.generateTokens(user.id, user.email);
-    return { accessToken };
+    const tokens = this.generateTokens(user.id, user.email);
+    await this.usersService.updateRefreshToken(user.id, tokens.refreshToken);
+    return tokens;
   }
 
   async checkEmail(email: string): Promise<{ available: boolean }> {
@@ -271,7 +272,7 @@ export class AuthService {
     return tokens;
   }
 
-  async adminRefresh(refreshToken: string): Promise<string> {
+  async adminRefresh(refreshToken: string): Promise<{ accessToken: string; refreshToken: string }> {
     let payload: { sub: number; email: string };
 
     try {
@@ -301,8 +302,9 @@ export class AuthService {
       });
     }
 
-    const { accessToken } = this.generateTokens(user.id, user.email);
-    return accessToken;
+    const tokens = this.generateTokens(user.id, user.email);
+    await this.usersService.updateRefreshToken(user.id, tokens.refreshToken);
+    return tokens;
   }
 
   private generateTokens(userId: number, email: string) {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -122,16 +122,19 @@ export class UsersService {
     countryCode: string;
     phoneNumber: string;
   }) {
-    const existing = await this.prisma.user.findUnique({ where: { email: data.email } });
-    if (existing) {
-      throw new ConflictException({
-        message: '이미 사용 중인 이메일입니다.',
-        errorCode: ErrorCode.EMAIL_ALREADY_EXISTS,
+    try {
+      return await this.prisma.user.create({
+        data: { ...data, password: null, provider: Provider.GOOGLE },
       });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+        throw new ConflictException({
+          message: '이미 사용 중인 이메일입니다.',
+          errorCode: ErrorCode.EMAIL_ALREADY_EXISTS,
+        });
+      }
+      throw e;
     }
-    return this.prisma.user.create({
-      data: { ...data, password: null, provider: Provider.GOOGLE },
-    });
   }
 
   async updateProfile(

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,5 +1,6 @@
 import { ConflictException, Injectable } from '@nestjs/common';
 import { Prisma, Provider } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../prisma/prisma.service';
 import { ErrorCode } from '../common/constants/error-codes';
 
@@ -61,7 +62,8 @@ export class UsersService {
   }
 
   async updateRefreshToken(id: number, refreshToken: string | null) {
-    await this.prisma.user.update({ where: { id }, data: { refreshToken } });
+    const hashed = refreshToken ? await bcrypt.hash(refreshToken, 10) : null;
+    await this.prisma.user.update({ where: { id }, data: { refreshToken: hashed } });
   }
 
   async updatePassword(id: number, hashedPassword: string) {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -145,7 +145,7 @@ export class UsersService {
   }
 
   async findAllPaginated(page: number, size: number) {
-    const [users, total] = await Promise.all([
+    const [users, total] = await this.prisma.$transaction([
       this.prisma.user.findMany({
         skip: page * size,
         take: size,


### PR DESCRIPTION
## 개요

코드 리뷰 과정에서 **실제 운영 환경에서 재현 가능한 버그 2건**과 **보안 취약점 2건**을 발견하여 수정합니다.

- **버그 #1**: 동시 Google 회원가입 요청 시 P2002 에러가 catch되지 않아 500 응답 노출
- **버그 #2**: 관리자 페이지 유저 목록의 `total`과 실제 데이터가 비트랜잭션 실행으로 불일치 가능
- **보안 #1**: refresh 토큰이 교체되지 않아 탈취 시 피해자 로그아웃 전까지 공격자가 지속 사용 가능
- **보안 #2**: DB에 refreshToken이 평문 저장되어 DB 유출 시 전체 세션 탈취 가능

각 이슈는 #20, #21, #22, #23으로 등록 후 수정했습니다.

---

## 변경 내용

### 🔴 버그 수정

#### `createGoogleUser` TOCTOU 레이스 컨디션 제거 (closes #20)
- **이전**: `findUnique` → `create` 순서로 별도 쿼리 실행. 동시 요청 시 P2002가 catch되지 않아 500 응답
- **이후**: check-then-act 패턴 제거, `create` 직접 시도 후 P2002 → `ConflictException` 변환

```ts
// Before
const existing = await this.prisma.user.findUnique({ where: { email } });
if (existing) throw new ConflictException(...);
return this.prisma.user.create({ data });   // P2002 미처리 → 500

// After
try {
  return await this.prisma.user.create({ data });
} catch (e) {
  if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002')
    throw new ConflictException(...);
  throw e;
}
```

#### `findAllPaginated` 트랜잭션 적용 (closes #21)
- **이전**: `Promise.all([findMany, count])` — 두 쿼리가 별개 트랜잭션으로 실행되어 사이에 INSERT/DELETE 발생 시 total 불일치
- **이후**: `prisma.$transaction([findMany, count])` — 동일 스냅샷에서 읽기 보장

### 🟡 보안 개선

#### Refresh Token Rotation 적용 (closes #22)
- **이전**: `refresh()` / `adminRefresh()` 가 accessToken만 재발급하고 refreshToken은 DB에 그대로 유지
- **이후**: 재발급 시 refreshToken도 새로 생성, DB 업데이트 후 클라이언트에 반환. `adminRefresh`는 쿠키도 재설정

#### refreshToken bcrypt 해시 저장 (closes #23)
- **이전**: DB에 refreshToken 평문 저장 → DB 유출 시 전체 세션 탈취
- **이후**: `updateRefreshToken` 저장 시 `bcrypt.hash(token, 10)` 적용, 검증 시 `bcrypt.compare` 사용

---

## 변경 파일

| 파일 | 내용 |
|---|---|
| `src/users/users.service.ts` | `createGoogleUser` TOCTOU 제거, `findAllPaginated` 트랜잭션, `updateRefreshToken` 해시 저장 |
| `src/auth/auth.service.ts` | `refresh` / `adminRefresh` token rotation, `bcrypt.compare` 검증 |
| `src/auth/auth.controller.ts` | `adminRefresh` 시 새 refreshToken 쿠키 재설정 |

---

## 배포 시 주의사항

> **⚠️ refreshToken 해시 저장(#23) 배포 직후 모든 기존 세션이 로그아웃됩니다.**
> DB에 평문으로 저장된 기존 토큰들이 bcrypt.compare 검증을 통과하지 못하기 때문입니다.
> 배포 전 사용자 공지 또는 maintenance window를 권장합니다.