### PR TITLE
[FEAT] Apple 로그인 API 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Get pnpm store path
         id: pnpm-cache

--- a/prisma/migrations/20260514000000_add_apple_login/migration.sql
+++ b/prisma/migrations/20260514000000_add_apple_login/migration.sql
@@ -1,0 +1,6 @@
+-- AlterEnum
+ALTER TABLE `users` MODIFY COLUMN `provider` ENUM('LOCAL', 'GOOGLE', 'APPLE') NOT NULL DEFAULT 'LOCAL';
+
+-- AlterTable
+ALTER TABLE `users` ADD COLUMN `appleId` VARCHAR(255) NULL,
+    ADD UNIQUE INDEX `users_appleId_key`(`appleId`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,7 @@ datasource db {
 enum Provider {
   LOCAL
   GOOGLE
+  APPLE
 }
 
 enum UserRole {
@@ -24,6 +25,7 @@ model User {
   name            String   @db.VarChar(100)
   password        String?  @db.VarChar(255)
   googleId        String?  @unique @db.VarChar(255)
+  appleId         String?  @unique @db.VarChar(255)
   birthDate       String   @db.VarChar(10)
   countryCode     String   @db.VarChar(10)
   phoneNumber     String   @db.VarChar(20)

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -26,6 +26,7 @@ import { LoginDto } from './dto/login.dto';
 import { ChangePasswordDto } from './dto/change-password.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { CheckEmailDto } from './dto/check-email.dto';
+import { AppleLoginDto } from './dto/apple-login.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { ErrorCode } from '../common/constants/error-codes';
 import { ResponseMessage } from '../common/decorators/response-message.decorator';
@@ -128,6 +129,25 @@ export class AuthController {
   ) {
     await this.authService.changePassword(req.user.id, dto);
     return null;
+  }
+
+  @ApiOperation({ summary: 'Apple 로그인' })
+  @ApiOkResponse({
+    description: 'Access/Refresh 토큰 발급',
+    schema: {
+      example: {
+        message: '성공',
+        data: {
+          accessToken: 'eyJhbGci...',
+          refreshToken: 'eyJhbGci...',
+        },
+      },
+    },
+  })
+  @Post('apple-login')
+  @HttpCode(HttpStatus.OK)
+  async appleLogin(@Body() dto: AppleLoginDto) {
+    return this.authService.appleLogin(dto.appleId, dto.email ?? null, dto.name ?? null);
   }
 
   @ApiOperation({ summary: '관리자 로그인' })

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -280,6 +280,28 @@ export class AuthService {
     };
   }
 
+  async appleLogin(appleId: string, email: string | null, name: string | null) {
+    const existingUser = await this.usersService.findByAppleId(appleId);
+
+    if (existingUser) {
+      const tokens = this.generateTokens(existingUser.id, existingUser.email);
+      await this.usersService.updateRefreshToken(existingUser.id, tokens.refreshToken);
+      return tokens;
+    }
+
+    if (!email || !name) {
+      throw new BadRequestException({
+        message: '최초 Apple 로그인 시 email과 name이 필요합니다.',
+        errorCode: ErrorCode.VALIDATION_FAILED,
+      });
+    }
+
+    const newUser = await this.usersService.createAppleUser({ appleId, email, name });
+    const tokens = this.generateTokens(newUser.id, newUser.email);
+    await this.usersService.updateRefreshToken(newUser.id, tokens.refreshToken);
+    return tokens;
+  }
+
   async adminLogin(
     email: string,
     password: string,

--- a/src/auth/dto/apple-login.dto.ts
+++ b/src/auth/dto/apple-login.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class AppleLoginDto {
+  @ApiProperty({ description: 'Apple unique user ID (sub claim)' })
+  @IsString()
+  appleId: string;
+
+  @ApiProperty({ description: '이메일 (최초 로그인 시에만 제공)', required: false, nullable: true })
+  @IsOptional()
+  @IsString()
+  email: string | null;
+
+  @ApiProperty({ description: '이름 (최초 로그인 시에만 제공)', required: false, nullable: true })
+  @IsOptional()
+  @IsString()
+  name: string | null;
+}

--- a/src/first-aid/services/openai.service.ts
+++ b/src/first-aid/services/openai.service.ts
@@ -18,9 +18,20 @@ interface AiAdviceResult {
   blogLinks: string[];
 }
 
+function detectLanguage(text: string): string {
+  if (/[가-힣]/.test(text)) return 'Korean';
+  if (/[ぁ-んァ-ン]/.test(text)) return 'Japanese';
+  if (/[一-龯]/.test(text)) return 'Chinese';
+  if (/[؀-ۿ]/.test(text)) return 'Arabic';
+  if (/[Ѐ-ӿ]/.test(text)) return 'Russian';
+  if (/[àáâãäåæçèéêëìíîïðñòóôõöùúûüýþÿÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝÞŸ]/.test(text))
+    return 'European (Spanish/French/German/Italian/Portuguese)';
+  return 'English';
+}
+
 const SYSTEM_PROMPT = `You are an emergency medical expert providing first-aid guidance for travelers.
 
-Detect the language of the "symptomDetail" field and respond ENTIRELY in that language. Never mix languages — all JSON fields must be in the same language.
+You MUST respond ENTIRELY in the language specified by the "responseLanguage" field. Never mix languages — all JSON fields must be written in that language.
 
 Respond ONLY with a JSON object:
 {
@@ -83,6 +94,8 @@ export class OpenAiService {
     countryCode: string,
   ): Promise<AiAdviceResult> {
     try {
+      const responseLanguage = detectLanguage(symptomDetail);
+
       const ragContext = await this.ragService.findRelevantDocuments(
         `${symptomType} ${symptomDetail}`,
       );
@@ -99,6 +112,7 @@ export class OpenAiService {
           {
             role: 'user',
             content: [
+              `responseLanguage: ${responseLanguage}`,
               `symptomType: ${symptomType}`,
               `symptomDetail: ${symptomDetail}`,
               `countryCode: ${countryCode}`,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -115,6 +115,54 @@ export class UsersService {
     });
   }
 
+  async findByAppleId(appleId: string) {
+    return this.prisma.user.findUnique({
+      where: { appleId },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        googleId: true,
+        appleId: true,
+        birthDate: true,
+        countryCode: true,
+        phoneNumber: true,
+        profileImageUrl: true,
+        provider: true,
+        role: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  async createAppleUser(data: {
+    appleId: string;
+    email: string;
+    name: string;
+  }) {
+    try {
+      return await this.prisma.user.create({
+        data: {
+          ...data,
+          password: null,
+          provider: Provider.APPLE,
+          birthDate: '',
+          countryCode: '',
+          phoneNumber: '',
+        },
+      });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+        throw new ConflictException({
+          message: '이미 사용 중인 이메일입니다.',
+          errorCode: ErrorCode.EMAIL_ALREADY_EXISTS,
+        });
+      }
+      throw e;
+    }
+  }
+
   async createGoogleUser(data: {
     email: string;
     name: string;


### PR DESCRIPTION
## 구현 내용

- `POST /api/auth/apple-login` 엔드포인트 추가
- `appleId`(sub claim)로 기존 유저 조회 → 토큰 발급
- 신규 유저 시 `email`, `name`으로 자동 가입 후 토큰 발급
- 재로그인 시 `email`/`name`이 `null`이어도 `appleId` 기반으로 정상 처리
- `Provider` enum에 `APPLE` 추가 및 DB 마이그레이션

## 주요 파일

- `prisma/schema.prisma` — `APPLE` Provider, `appleId` 필드 추가
- `prisma/migrations/20260514000000_add_apple_login/migration.sql`
- `src/auth/dto/apple-login.dto.ts` — 신규 DTO
- `src/auth/auth.service.ts` — `appleLogin()` 메서드
- `src/users/users.service.ts` — `findByAppleId()`, `createAppleUser()`
- `src/auth/auth.controller.ts` — 엔드포인트 등록

## 테스트 방법

**최초 로그인 (신규 유저)**
```bash
curl -X POST http://localhost:3000/api/auth/apple-login \
  -H "Content-Type: application/json" \
  -d '{"appleId":"001234.abc","email":"user@icloud.com","name":"홍길동"}'
```

**재로그인 (기존 유저, email/name null)**
```bash
curl -X POST http://localhost:3000/api/auth/apple-login \
  -H "Content-Type: application/json" \
  -d '{"appleId":"001234.abc","email":null,"name":null}'
```

**응답 예시**
```json
{
  "message": "성공",
  "data": {
    "accessToken": "eyJhbGci...",
    "refreshToken": "eyJhbGci..."
  }
}
```