### PR TITLE
[FEAT] Apple 로그인 isNewUser 응답 추가 및 프로필 업데이트 엔드포인트 구현

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -286,7 +286,7 @@ export class AuthService {
     if (existingUser) {
       const tokens = this.generateTokens(existingUser.id, existingUser.email);
       await this.usersService.updateRefreshToken(existingUser.id, tokens.refreshToken);
-      return tokens;
+      return { ...tokens, isNewUser: false };
     }
 
     if (!email || !name) {
@@ -299,7 +299,7 @@ export class AuthService {
     const newUser = await this.usersService.createAppleUser({ appleId, email, name });
     const tokens = this.generateTokens(newUser.id, newUser.email);
     await this.usersService.updateRefreshToken(newUser.id, tokens.refreshToken);
-    return tokens;
+    return { ...tokens, isNewUser: true };
   }
 
   async adminLogin(

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, HttpCode, HttpStatus, Patch, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { UsersService } from './users.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CompleteProfileDto } from '../auth/dto/complete-profile.dto';
+
+@ApiTags('Users')
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @ApiOperation({ summary: '프로필 업데이트 (JWT 필요)' })
+  @ApiBearerAuth('access-token')
+  @ApiOkResponse({
+    description: '프로필 업데이트 성공',
+    schema: { example: { message: '성공', data: null } },
+  })
+  @UseGuards(JwtAuthGuard)
+  @Patch('profile')
+  @HttpCode(HttpStatus.OK)
+  async updateProfile(
+    @Request() req: { user: { id: number } },
+    @Body() dto: CompleteProfileDto,
+  ) {
+    await this.usersService.updateProfile(req.user.id, dto);
+    return null;
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
+  controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],
 })


### PR DESCRIPTION
Closes #29

## 구현 내용

- `POST /auth/apple-login` 응답에 `isNewUser` 플래그 추가
  - 신규 유저: `isNewUser: true`
  - 기존 유저: `isNewUser: false`
- `PATCH /users/profile` 엔드포인트 신규 추가 (JWT 인증 필요)
  - 요청 필드: `name`, `birthDate`, `countryCode`, `phoneNumber`
  - Apple 신규 유저가 추가 정보 입력 후 저장하는 용도

## 주요 파일

- `src/auth/auth.service.ts` — `appleLogin` 반환값에 `isNewUser` 추가
- `src/users/users.controller.ts` — `PATCH /users/profile` 컨트롤러 신규 생성
- `src/users/users.module.ts` — `UsersController` 등록

## 테스트 방법

**Apple 로그인 (신규 유저)**
```bash
curl -X POST http://localhost:3000/api/auth/apple-login \
  -H "Content-Type: application/json" \
  -d '{"appleId": "test.apple.id.001", "email": "test@apple.com", "name": "테스트"}'
# 응답: { "accessToken": "...", "refreshToken": "...", "isNewUser": true }
```

**프로필 업데이트**
```bash
curl -X PATCH http://localhost:3000/api/users/profile \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <accessToken>" \
  -d '{"name": "테스트", "birthDate": "2000-01-01", "countryCode": "KR", "phoneNumber": "+821012345678"}'
# 응답: { "message": "성공", "data": null }
```