### PR TITLE
[FEAT] 응급처치 백과사전 모듈 추가 

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { PrismaModule } from './prisma/prisma.module';
 import { FirstAidModule } from './first-aid/first-aid.module';
+import { EncyclopediaModule } from './encyclopedia/encyclopedia.module';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { UserModule } from './user/user.module';
@@ -17,6 +18,7 @@ import { LoggerMiddleware } from './common/middleware/logger.middleware';
     }),
     PrismaModule,
     FirstAidModule,
+    EncyclopediaModule,
     AuthModule,
     UsersModule,
     UserModule,

--- a/src/encyclopedia/dto/encyclopedia-query.dto.ts
+++ b/src/encyclopedia/dto/encyclopedia-query.dto.ts
@@ -1,0 +1,10 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class EncyclopediaQueryDto {
+  @ApiPropertyOptional({ example: 'burn', description: '검색 키워드' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  search?: string;
+}

--- a/src/encyclopedia/encyclopedia.controller.ts
+++ b/src/encyclopedia/encyclopedia.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { EncyclopediaService } from './encyclopedia.service';
+import { EncyclopediaQueryDto } from './dto/encyclopedia-query.dto';
+
+@ApiTags('Encyclopedia')
+@Controller('encyclopedia')
+export class EncyclopediaController {
+  constructor(private readonly encyclopediaService: EncyclopediaService) {}
+
+  @ApiOperation({ summary: '응급처치 백과사전 목록 (NIH 데이터, 인증 불필요)' })
+  @ApiOkResponse({
+    description: '의학 증상/질환 목록',
+    schema: {
+      example: {
+        message: '성공',
+        data: {
+          total: 500,
+          items: [{ id: 'condition-0', name: 'Burn', icdCodes: ['T30'] }],
+        },
+      },
+    },
+  })
+  @Get()
+  getConditions(@Query() query: EncyclopediaQueryDto) {
+    return this.encyclopediaService.getConditions(query.search);
+  }
+}

--- a/src/encyclopedia/encyclopedia.module.ts
+++ b/src/encyclopedia/encyclopedia.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { EncyclopediaController } from './encyclopedia.controller';
+import { EncyclopediaService } from './encyclopedia.service';
+
+@Module({
+  controllers: [EncyclopediaController],
+  providers: [EncyclopediaService],
+})
+export class EncyclopediaModule {}

--- a/src/encyclopedia/encyclopedia.service.ts
+++ b/src/encyclopedia/encyclopedia.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger } from '@nestjs/common';
+import axios from 'axios';
+
+export interface EncyclopediaItem {
+  id: string;
+  name: string;
+  icdCodes: string[];
+}
+
+// NIH API: [total, codes[], extraFields | null, rows[][]]
+type NihResponse = [number, string[], Record<string, (string[] | null)[]> | null, string[][]];
+
+@Injectable()
+export class EncyclopediaService {
+  private readonly logger = new Logger(EncyclopediaService.name);
+  private readonly NIH_API = 'https://clinicaltables.nlm.nih.gov/api/conditions/v3/search';
+  private readonly CACHE_TTL = 24 * 60 * 60 * 1000;
+
+  private cache: { items: EncyclopediaItem[]; cachedAt: number } | null = null;
+
+  async getConditions(
+    search?: string,
+  ): Promise<{ total: number; items: EncyclopediaItem[] }> {
+    const all = await this.loadAll();
+
+    if (!search?.trim()) {
+      return { total: all.length, items: all };
+    }
+
+    const keyword = search.trim().toLowerCase();
+    const filtered = all.filter((item) =>
+      item.name.toLowerCase().includes(keyword),
+    );
+    return { total: filtered.length, items: filtered };
+  }
+
+  private async loadAll(): Promise<EncyclopediaItem[]> {
+    if (this.cache && Date.now() - this.cache.cachedAt < this.CACHE_TTL) {
+      return this.cache.items;
+    }
+
+    try {
+      const { data } = await axios.get<NihResponse>(this.NIH_API, {
+        params: { terms: '', maxList: 500, ef: 'icd10cm_codes' },
+        timeout: 10000,
+      });
+
+      const [, , extraFields, rows] = data;
+      const icdMap = extraFields?.icd10cm_codes ?? [];
+
+      const items: EncyclopediaItem[] = rows.map((row, i) => ({
+        id: `condition-${i}`,
+        name: row[0],
+        icdCodes: icdMap[i] ?? [],
+      }));
+
+      this.cache = { items, cachedAt: Date.now() };
+      this.logger.log(`NIH 데이터 캐싱 완료: ${items.length}개`);
+      return items;
+    } catch (error) {
+      this.logger.error(`NIH API 호출 실패: ${(error as Error).message}`);
+      return this.cache?.items ?? [];
+    }
+  }
+}


### PR DESCRIPTION
## 관련 이슈

closes #33

## 변경 사항

NIH Clinical Table Search API 기반의 응급처치 백과사전 모듈을 독립적인 NestJS 모듈로 추가합니다.

### 추가된 파일

| 파일 | 설명 |
|------|------|
| `src/encyclopedia/encyclopedia.module.ts` | NestJS 모듈 등록 |
| `src/encyclopedia/encyclopedia.controller.ts` | `GET /api/encyclopedia` 엔드포인트 |
| `src/encyclopedia/encyclopedia.service.ts` | NIH API 호출 + 24시간 인메모리 캐시 |
| `src/encyclopedia/dto/encyclopedia-query.dto.ts` | `search` 쿼리 파라미터 검증 |

### 수정된 파일

- `src/app.module.ts` — `EncyclopediaModule` 등록

## 설계 결정

**`first-aid` 모듈과 분리한 이유**
- `EncyclopediaService`는 Geocoding, OpenAI, RAG 등 first-aid 내부 서비스와 의존관계 없음
- 프론트 여러 페이지에서 공통으로 사용되는 독립 도메인
- 향후 상세 엔드포인트(`GET /api/encyclopedia/:id`) 추가 시 first-aid를 건드리지 않아도 됨

**인메모리 캐시를 선택한 이유**
- 의학 증상 목록은 하루에 변하지 않는 정적 데이터
- 단일 서버 + 수백 KB 규모 → Redis 도입은 오버엔지니어링
- 24시간 TTL, 만료 시 자동 재갱신

## 엔드포인트

```
GET /api/encyclopedia           # 전체 500개+ 목록
GET /api/encyclopedia?search=burn  # 키워드 필터링
```

## 테스트 방법

```bash
# 전체 목록
curl http://localhost:3000/api/encyclopedia

# 검색
curl "http://localhost:3000/api/encyclopedia?search=burn"
```