### PR TITLE
[FEAT] 건강 백과사전 데이터소스 전환 및 DB 기반 조회 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "prisma:migrate": "prisma migrate dev",
     "prisma:deploy": "prisma migrate deploy",
     "prisma:studio": "prisma studio",
+    "seed:encyclopedia": "ts-node -P prisma/tsconfig.json prisma/seed-encyclopedia.ts",
     "seed:vectors": "ts-node -P scripts/tsconfig.json scripts/generate-vectors.ts",
     "seed:vectors:prod": "node dist-scripts/generate-vectors.js",
     "measure:rag": "ts-node -P scripts/tsconfig.json scripts/measure-rag.ts",

--- a/prisma/migrations/20260515000000_add_conditions_table/migration.sql
+++ b/prisma/migrations/20260515000000_add_conditions_table/migration.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `conditions` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(255) NOT NULL,
+    `icdCodes` TEXT NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/migrations/20260515100000_replace_conditions_with_health_topics/migration.sql
+++ b/prisma/migrations/20260515100000_replace_conditions_with_health_topics/migration.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS `conditions`;
+
+CREATE TABLE `health_topics` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `title` VARCHAR(255) NOT NULL,
+    `altTitles` TEXT NOT NULL,
+    `summary` TEXT NOT NULL,
+    `fullSummary` LONGTEXT NOT NULL,
+    `categories` TEXT NOT NULL,
+    `meshTerms` TEXT NOT NULL,
+    `url` VARCHAR(500) NOT NULL,
+
+    UNIQUE INDEX `health_topics_url_key`(`url`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,19 @@ enum UserRole {
   ADMIN
 }
 
+model HealthTopic {
+  id          Int    @id @default(autoincrement())
+  title       String @db.VarChar(255)
+  altTitles   String @db.Text
+  summary     String @db.Text
+  fullSummary String @db.LongText
+  categories  String @db.Text
+  meshTerms   String @db.Text
+  url         String @unique @db.VarChar(500)
+
+  @@map("health_topics")
+}
+
 model User {
   id              Int      @id @default(autoincrement())
   email           String   @unique @db.VarChar(255)

--- a/prisma/seed-encyclopedia.ts
+++ b/prisma/seed-encyclopedia.ts
@@ -1,0 +1,138 @@
+import { PrismaClient } from '@prisma/client';
+import axios from 'axios';
+
+const prisma = new PrismaClient();
+
+const API = 'https://wsearch.nlm.nih.gov/ws/query';
+const TARGET = 500;
+const RETMAX = 50;
+const DELAY_MS = 800;
+
+const TERMS = [
+  'first aid', 'emergency', 'injury', 'wound', 'burn', 'fracture', 'bleeding',
+  'poisoning', 'choking', 'shock', 'concussion',
+  'infection', 'bacteria', 'virus', 'fever', 'malaria', 'hepatitis', 'typhoid',
+  'heart', 'lung', 'brain', 'liver', 'kidney', 'skin', 'eye', 'ear', 'bone',
+  'blood', 'muscle', 'digestive', 'respiratory', 'immune', 'joint',
+  'diabetes', 'cancer', 'allergy', 'asthma', 'arthritis', 'hypertension',
+  'stroke', 'headache', 'pain', 'anxiety', 'depression', 'obesity',
+  'nausea', 'dizziness', 'fatigue', 'rash', 'swelling', 'seizure', 'cough',
+  'heat illness', 'altitude', 'cold', 'food', 'insect', 'bite',
+  'nutrition', 'sleep', 'pregnancy', 'child', 'surgery', 'vaccine',
+  'dental', 'spine', 'nerve', 'stomach', 'thyroid', 'hormones',
+];
+
+interface Topic {
+  url: string;
+  title: string;
+  altTitles: string[];
+  summary: string;
+  fullSummary: string;
+  categories: string[];
+  meshTerms: string[];
+}
+
+function decodeXml(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+function clean(raw: string): string {
+  return stripHtml(decodeXml(raw));
+}
+
+function getFields(body: string, name: string): string[] {
+  const re = new RegExp(`<content name="${name}">([\s\S]*?)<\\/content>`, 'g');
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) out.push(m[1]);
+  return out;
+}
+
+function parseXml(xml: string): Topic[] {
+  const docRe = /<document rank="\d+" url="([^"]+)">([\s\S]*?)<\/document>/g;
+  const topics: Topic[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = docRe.exec(xml)) !== null) {
+    const [, url, body] = m;
+    const title = clean(getFields(body, 'title')[0] ?? '');
+    if (!title) continue;
+    topics.push({
+      url,
+      title,
+      altTitles: getFields(body, 'altTitle').map(clean).filter(Boolean),
+      fullSummary: clean(getFields(body, 'FullSummary')[0] ?? ''),
+      summary: clean(getFields(body, 'snippet')[0] ?? ''),
+      categories: getFields(body, 'groupName').map(clean).filter(Boolean),
+      meshTerms: getFields(body, 'mesh').map(clean).filter(Boolean),
+    });
+  }
+  return topics;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function fetchTopics(term: string): Promise<Topic[]> {
+  const { data } = await axios.get<string>(API, {
+    params: { db: 'healthTopics', term, retmax: RETMAX },
+    responseType: 'text',
+    timeout: 15000,
+  });
+  return parseXml(data);
+}
+
+async function main() {
+  const existing = await prisma.healthTopic.count();
+  if (existing > 0) {
+    console.log(`이미 ${existing}개 존재. 스킵합니다.`);
+    return;
+  }
+
+  const seen = new Set<string>();
+  const collected: Topic[] = [];
+
+  for (const term of TERMS) {
+    if (collected.length >= TARGET) break;
+    try {
+      process.stdout.write(`[${collected.length}/${TARGET}] "${term}" 검색 중...\r`);
+      const topics = await fetchTopics(term);
+      for (const t of topics) {
+        if (seen.has(t.url)) continue;
+        seen.add(t.url);
+        collected.push(t);
+        if (collected.length >= TARGET) break;
+      }
+    } catch (e) {
+      console.error(`\n"${term}" 실패: ${(e as Error).message}`);
+    }
+    await sleep(DELAY_MS);
+  }
+
+  console.log(`\n총 ${collected.length}개 DB에 저장 중...`);
+  await prisma.healthTopic.createMany({
+    data: collected.map((t) => ({
+      title: t.title,
+      altTitles: JSON.stringify(t.altTitles),
+      summary: t.summary,
+      fullSummary: t.fullSummary,
+      categories: JSON.stringify(t.categories),
+      meshTerms: JSON.stringify(t.meshTerms),
+      url: t.url,
+    })),
+    skipDuplicates: true,
+  });
+  console.log(`완료: ${collected.length}개 저장됨`);
+}
+
+main()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());

--- a/prisma/tsconfig.json
+++ b/prisma/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "resolvePackageJsonExports": false,
+    "outDir": "../dist-prisma",
+    "rootDir": "."
+  },
+  "include": ["./**/*.ts"]
+}

--- a/src/encyclopedia/encyclopedia.controller.ts
+++ b/src/encyclopedia/encyclopedia.controller.ts
@@ -8,21 +8,30 @@ import { EncyclopediaQueryDto } from './dto/encyclopedia-query.dto';
 export class EncyclopediaController {
   constructor(private readonly encyclopediaService: EncyclopediaService) {}
 
-  @ApiOperation({ summary: '응급처치 백과사전 목록 (NIH 데이터, 인증 불필요)' })
+  @ApiOperation({ summary: '건강 백과사전 목록 (MedlinePlus 데이터, 인증 불필요)' })
   @ApiOkResponse({
-    description: '의학 증상/질환 목록',
+    description: '질병·증상·응급처치 건강 주제 목록',
     schema: {
       example: {
         message: '성공',
         data: {
           total: 500,
-          items: [{ id: 'condition-0', name: 'Burn', icdCodes: ['T30'] }],
+          items: [
+            {
+              id: 1,
+              title: 'Burns',
+              altTitles: ['Chemical Burns', 'Thermal Burns'],
+              summary: 'Burns are injuries to skin or other tissue caused by heat...',
+              categories: ['Injuries and Wounds'],
+              url: 'https://medlineplus.gov/burns.html',
+            },
+          ],
         },
       },
     },
   })
   @Get()
-  getConditions(@Query() query: EncyclopediaQueryDto) {
-    return this.encyclopediaService.getConditions(query.search);
+  getTopics(@Query() query: EncyclopediaQueryDto) {
+    return this.encyclopediaService.getTopics(query.search);
   }
 }

--- a/src/encyclopedia/encyclopedia.service.ts
+++ b/src/encyclopedia/encyclopedia.service.ts
@@ -1,70 +1,56 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import axios from 'axios';
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
 
-export interface EncyclopediaItem {
-  id: string;
-  name: string;
-  icdCodes: string[];
+export interface HealthTopicItem {
+  id: number;
+  title: string;
+  altTitles: string[];
+  summary: string;
+  categories: string[];
+  url: string;
 }
 
-// NIH API: [total, codes[], extraFields | null, rows[][]]
-type NihResponse = [number, string[], Record<string, (string[] | null)[]> | null, string[][]];
-
 @Injectable()
-export class EncyclopediaService implements OnModuleInit {
-  private readonly logger = new Logger(EncyclopediaService.name);
-  private readonly NIH_API = 'https://clinicaltables.nlm.nih.gov/api/conditions/v3/search';
-  private readonly CACHE_TTL = 24 * 60 * 60 * 1000;
+export class EncyclopediaService {
+  constructor(private readonly prisma: PrismaService) {}
 
-  private cache: { items: EncyclopediaItem[]; cachedAt: number } | null = null;
-
-  onModuleInit() {
-    void this.loadAll();
-  }
-
-
-  async getConditions(
+  async getTopics(
     search?: string,
-  ): Promise<{ total: number; items: EncyclopediaItem[] }> {
-    const all = await this.loadAll();
+  ): Promise<{ total: number; items: HealthTopicItem[] }> {
+    const keyword = search?.trim();
+    const where = keyword
+      ? {
+          OR: [
+            { title: { contains: keyword } },
+            { altTitles: { contains: keyword } },
+          ],
+        }
+      : {};
 
-    if (!search?.trim()) {
-      return { total: all.length, items: all };
-    }
+    const [total, rows] = await Promise.all([
+      this.prisma.healthTopic.count({ where }),
+      this.prisma.healthTopic.findMany({
+        where,
+        select: {
+          id: true,
+          title: true,
+          altTitles: true,
+          summary: true,
+          categories: true,
+          url: true,
+        },
+        orderBy: { title: 'asc' },
+        take: 100,
+      }),
+    ]);
 
-    const keyword = search.trim().toLowerCase();
-    const filtered = all.filter((item) =>
-      item.name.toLowerCase().includes(keyword),
-    );
-    return { total: filtered.length, items: filtered };
-  }
-
-  private async loadAll(): Promise<EncyclopediaItem[]> {
-    if (this.cache && Date.now() - this.cache.cachedAt < this.CACHE_TTL) {
-      return this.cache.items;
-    }
-
-    try {
-      const { data } = await axios.get<NihResponse>(this.NIH_API, {
-        params: { terms: '', maxList: 500, ef: 'icd10cm_codes' },
-        timeout: 10000,
-      });
-
-      const [, , extraFields, rows] = data;
-      const icdMap = extraFields?.icd10cm_codes ?? [];
-
-      const items: EncyclopediaItem[] = rows.map((row, i) => ({
-        id: `condition-${i}`,
-        name: row[0],
-        icdCodes: icdMap[i] ?? [],
-      }));
-
-      this.cache = { items, cachedAt: Date.now() };
-      this.logger.log(`NIH 데이터 캐싱 완료: ${items.length}개`);
-      return items;
-    } catch (error) {
-      this.logger.error(`NIH API 호출 실패: ${(error as Error).message}`);
-      return this.cache?.items ?? [];
-    }
+    return {
+      total,
+      items: rows.map((r): HealthTopicItem => ({
+        ...r,
+        altTitles: JSON.parse(r.altTitles) as string[],
+        categories: JSON.parse(r.categories) as string[],
+      })),
+    };
   }
 }


### PR DESCRIPTION
Closes #35

## 구현 내용

- `conditions` 테이블을 `health_topics`로 교체 — `title`, `altTitles`, `summary`, `fullSummary`, `categories`, `meshTerms`, `url` 필드 포함
- MedlinePlus Web Service API 기반 seed 스크립트 추가 — 70개 키워드 순회, 500개 health topic 수집 및 HTML 파싱
- `EncyclopediaService` NIH API 인메모리 캐시 방식 → Prisma DB 직접 조회 방식으로 전환
- 검색 시 `title`, `altTitles` 양쪽에서 키워드 매칭

## 주요 파일

- `prisma/schema.prisma` — HealthTopic 모델 추가
- `prisma/migrations/20260515100000_replace_conditions_with_health_topics/` — 마이그레이션
- `prisma/seed-encyclopedia.ts` — MedlinePlus XML 파싱 및 DB seed
- `src/encyclopedia/encyclopedia.service.ts` — DB 쿼리 기반으로 전환
- `src/encyclopedia/encyclopedia.controller.ts` — 응답 구조 업데이트

## 배포 시 실행 필요

```bash
# 마이그레이션 + seed (컨테이너 내부에서)
pnpm prisma:deploy && pnpm seed:encyclopedia
```

## 테스트 방법

```bash
# 전체 목록
curl http://localhost:3000/api/encyclopedia

# 키워드 검색
curl "http://localhost:3000/api/encyclopedia?search=burn"
```