### PR TITLE
[FIX] first_aid_logs 마이그레이션 파일 추가

### DIFF
--- a/prisma/migrations/20260529000000_add_first_aid_logs/migration.sql
+++ b/prisma/migrations/20260529000000_add_first_aid_logs/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE `first_aid_logs` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `userId` INTEGER NULL,
+    `symptomType` ENUM('BLEEDING', 'BURNS', 'FRACTURE', 'ALLERGIC_REACTION', 'SEIZURE', 'HEATSTROKE', 'HYPOTHERMIA', 'POISONING', 'BREATHING_DIFFICULTY', 'ANIMAL_BITE', 'FALL_INJURY') NOT NULL,
+    `countryCode` VARCHAR(10) NOT NULL,
+    `confidence` INTEGER NOT NULL,
+    `requestedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `first_aid_logs_symptomType_idx`(`symptomType`),
+    INDEX `first_aid_logs_countryCode_idx`(`countryCode`),
+    INDEX `first_aid_logs_requestedAt_idx`(`requestedAt`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `first_aid_logs` ADD CONSTRAINT `first_aid_logs_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
## 원인

`prisma migrate deploy`는 `prisma/migrations/` 폴더의 SQL 파일을 적용합니다.
스키마에 `FirstAidLog` 모델을 추가했지만 마이그레이션 파일을 생성하지 않아 배포 후에도 테이블이 생성되지 않았습니다.

## 수정

`first_aid_logs` 테이블 생성 마이그레이션 SQL 파일 추가.

## 배포 후 동작

컨테이너 시작 시 `pnpm prisma:deploy`가 자동으로 마이그레이션을 적용하여 `first_aid_logs` 테이블이 생성됩니다.