### PR TITLE
[TEST] 핵심 서비스 유닛 테스트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.[jt]s$": "$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -9,13 +9,11 @@ import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { UserRole } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
-import axios from 'axios';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 
 jest.mock('axios');
 jest.mock('bcrypt');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
 const mockedBcrypt = bcrypt as jest.Mocked<typeof bcrypt>;
 
 const mockUsersService = {
@@ -114,9 +112,9 @@ describe('AuthService', () => {
     });
 
     it('비밀번호 불일치 → BadRequestException', async () => {
-      await expect(service.signup({ ...dto, passwordConfirm: 'WrongPass1!' })).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        service.signup({ ...dto, passwordConfirm: 'WrongPass1!' }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
@@ -136,26 +134,29 @@ describe('AuthService', () => {
     it('존재하지 않는 이메일 → NotFoundException', async () => {
       mockUsersService.findByEmailWithPassword.mockResolvedValue(null);
 
-      await expect(service.login('none@example.com', 'Password1!')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.login('none@example.com', 'Password1!'),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it('소셜 로그인 계정(password null) → BadRequestException', async () => {
-      mockUsersService.findByEmailWithPassword.mockResolvedValue({ ...mockUser, password: null });
+      mockUsersService.findByEmailWithPassword.mockResolvedValue({
+        ...mockUser,
+        password: null,
+      });
 
-      await expect(service.login('test@example.com', 'Password1!')).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        service.login('test@example.com', 'Password1!'),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('잘못된 비밀번호 → UnauthorizedException', async () => {
       mockUsersService.findByEmailWithPassword.mockResolvedValue(mockUser);
       mockedBcrypt.compare.mockResolvedValue(false as never);
 
-      await expect(service.login('test@example.com', 'WrongPass!')).rejects.toThrow(
-        UnauthorizedException,
-      );
+      await expect(
+        service.login('test@example.com', 'WrongPass!'),
+      ).rejects.toThrow(UnauthorizedException);
     });
   });
 
@@ -171,7 +172,10 @@ describe('AuthService', () => {
 
   describe('refresh', () => {
     it('유효한 토큰 → 새 토큰 반환 및 rotation', async () => {
-      mockJwtService.verify.mockReturnValue({ sub: 1, email: 'test@example.com' });
+      mockJwtService.verify.mockReturnValue({
+        sub: 1,
+        email: 'test@example.com',
+      });
       mockUsersService.findByIdWithRefreshToken.mockResolvedValue(mockUser);
       mockedBcrypt.compare.mockResolvedValue(true as never);
       mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
@@ -187,27 +191,38 @@ describe('AuthService', () => {
         throw new Error('invalid');
       });
 
-      await expect(service.refresh('bad.token')).rejects.toThrow(UnauthorizedException);
+      await expect(service.refresh('bad.token')).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
 
     it('refreshToken bcrypt 불일치 → UnauthorizedException', async () => {
-      mockJwtService.verify.mockReturnValue({ sub: 1, email: 'test@example.com' });
+      mockJwtService.verify.mockReturnValue({
+        sub: 1,
+        email: 'test@example.com',
+      });
       mockUsersService.findByIdWithRefreshToken.mockResolvedValue(mockUser);
       mockedBcrypt.compare.mockResolvedValue(false as never);
 
-      await expect(service.refresh('wrong.refresh.token')).rejects.toThrow(UnauthorizedException);
+      await expect(service.refresh('wrong.refresh.token')).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
   });
 
   describe('checkEmail', () => {
     it('미존재 이메일 → available: true', async () => {
       mockUsersService.existsByEmail.mockResolvedValue(false);
-      expect((await service.checkEmail('new@example.com')).available).toBe(true);
+      expect((await service.checkEmail('new@example.com')).available).toBe(
+        true,
+      );
     });
 
     it('존재 이메일 → available: false', async () => {
       mockUsersService.existsByEmail.mockResolvedValue(true);
-      expect((await service.checkEmail('existing@example.com')).available).toBe(false);
+      expect((await service.checkEmail('existing@example.com')).available).toBe(
+        false,
+      );
     });
   });
 
@@ -226,7 +241,10 @@ describe('AuthService', () => {
 
       await service.changePassword(1, dto);
 
-      expect(mockUsersService.updatePassword).toHaveBeenCalledWith(1, 'newHashed');
+      expect(mockUsersService.updatePassword).toHaveBeenCalledWith(
+        1,
+        'newHashed',
+      );
     });
 
     it('새 비밀번호 불일치 → BadRequestException', async () => {
@@ -236,16 +254,23 @@ describe('AuthService', () => {
     });
 
     it('소셜 로그인 계정 → BadRequestException', async () => {
-      mockUsersService.findByIdWithPassword.mockResolvedValue({ ...mockUser, password: null });
+      mockUsersService.findByIdWithPassword.mockResolvedValue({
+        ...mockUser,
+        password: null,
+      });
 
-      await expect(service.changePassword(1, dto)).rejects.toThrow(BadRequestException);
+      await expect(service.changePassword(1, dto)).rejects.toThrow(
+        BadRequestException,
+      );
     });
 
     it('현재 비밀번호 불일치 → UnauthorizedException', async () => {
       mockUsersService.findByIdWithPassword.mockResolvedValue(mockUser);
       mockedBcrypt.compare.mockResolvedValue(false as never);
 
-      await expect(service.changePassword(1, dto)).rejects.toThrow(UnauthorizedException);
+      await expect(service.changePassword(1, dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
   });
 
@@ -256,7 +281,10 @@ describe('AuthService', () => {
       mockedBcrypt.compare.mockResolvedValue(true as never);
       mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
 
-      const result = await service.adminLogin('admin@example.com', 'AdminPass1!');
+      const result = await service.adminLogin(
+        'admin@example.com',
+        'AdminPass1!',
+      );
 
       expect(result.accessToken).toBeTruthy();
     });
@@ -265,9 +293,9 @@ describe('AuthService', () => {
       mockUsersService.findByEmailWithPassword.mockResolvedValue(null);
       const compareSpy = mockedBcrypt.compare.mockResolvedValue(false as never);
 
-      await expect(service.adminLogin('none@example.com', 'Pass1!')).rejects.toThrow(
-        UnauthorizedException,
-      );
+      await expect(
+        service.adminLogin('none@example.com', 'Pass1!'),
+      ).rejects.toThrow(UnauthorizedException);
       expect(compareSpy).toHaveBeenCalled();
     });
 
@@ -275,17 +303,20 @@ describe('AuthService', () => {
       mockUsersService.findByEmailWithPassword.mockResolvedValue(mockUser);
       mockedBcrypt.compare.mockResolvedValue(true as never);
 
-      await expect(service.adminLogin('test@example.com', 'Pass1!')).rejects.toThrow(
-        ForbiddenException,
-      );
+      await expect(
+        service.adminLogin('test@example.com', 'Pass1!'),
+      ).rejects.toThrow(ForbiddenException);
     });
 
     it('소셜 로그인 계정 → UnauthorizedException', async () => {
-      mockUsersService.findByEmailWithPassword.mockResolvedValue({ ...mockUser, password: null });
+      mockUsersService.findByEmailWithPassword.mockResolvedValue({
+        ...mockUser,
+        password: null,
+      });
 
-      await expect(service.adminLogin('test@example.com', 'Pass1!')).rejects.toThrow(
-        UnauthorizedException,
-      );
+      await expect(
+        service.adminLogin('test@example.com', 'Pass1!'),
+      ).rejects.toThrow(UnauthorizedException);
     });
   });
 
@@ -305,7 +336,11 @@ describe('AuthService', () => {
       mockUsersService.linkAppleId.mockResolvedValue(undefined);
       mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
 
-      const result = await service.appleLogin('apple123', 'test@example.com', 'Test');
+      const result = await service.appleLogin(
+        'apple123',
+        'test@example.com',
+        'Test',
+      );
 
       expect(mockUsersService.linkAppleId).toHaveBeenCalledWith(1, 'apple123');
       expect(result.isNewUser).toBe(false);
@@ -317,7 +352,11 @@ describe('AuthService', () => {
       mockUsersService.createAppleUser.mockResolvedValue(mockUser);
       mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
 
-      const result = await service.appleLogin('apple123', 'new@example.com', 'New User');
+      const result = await service.appleLogin(
+        'apple123',
+        'new@example.com',
+        'New User',
+      );
 
       expect(result.isNewUser).toBe(true);
     });
@@ -325,7 +364,9 @@ describe('AuthService', () => {
     it('최초 로그인에 email/name 없음 → BadRequestException', async () => {
       mockUsersService.findByAppleId.mockResolvedValue(null);
 
-      await expect(service.appleLogin('apple123', null, null)).rejects.toThrow(BadRequestException);
+      await expect(service.appleLogin('apple123', null, null)).rejects.toThrow(
+        BadRequestException,
+      );
     });
   });
 });

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,331 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { UserRole } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+import axios from 'axios';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+
+jest.mock('axios');
+jest.mock('bcrypt');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedBcrypt = bcrypt as jest.Mocked<typeof bcrypt>;
+
+const mockUsersService = {
+  create: jest.fn(),
+  findByEmailWithPassword: jest.fn(),
+  findByIdWithRefreshToken: jest.fn(),
+  findByIdWithPassword: jest.fn(),
+  findByEmail: jest.fn(),
+  findByGoogleId: jest.fn(),
+  findByAppleId: jest.fn(),
+  existsByEmail: jest.fn(),
+  updateRefreshToken: jest.fn(),
+  updatePassword: jest.fn(),
+  createGoogleUser: jest.fn(),
+  createAppleUser: jest.fn(),
+  linkGoogleId: jest.fn(),
+  linkAppleId: jest.fn(),
+};
+
+const mockJwtService = {
+  sign: jest.fn().mockReturnValue('mock.token'),
+  verify: jest.fn(),
+};
+
+const mockConfigService = {
+  get: jest.fn().mockImplementation((key: string) => {
+    const config: Record<string, string> = {
+      JWT_SECRET: 'test-secret',
+      JWT_REFRESH_SECRET: 'test-refresh-secret',
+      JWT_REFRESH_EXPIRES_IN: '30d',
+      GOOGLE_CLIENT_ID: 'test-client-id',
+      GOOGLE_CLIENT_SECRET: 'test-client-secret',
+      GOOGLE_CALLBACK_URL: 'http://localhost:3000/callback',
+    };
+    return config[key];
+  }),
+};
+
+const mockUser = {
+  id: 1,
+  email: 'test@example.com',
+  name: 'Test User',
+  password: '$2b$12$hashedpassword',
+  role: UserRole.USER,
+  provider: 'LOCAL',
+  refreshToken: '$2b$12$hashedrefresh',
+  googleId: null,
+  appleId: null,
+  birthDate: '1990-01-01',
+  countryCode: 'KR',
+  phoneNumber: '+821012345678',
+  profileImageUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: JwtService, useValue: mockJwtService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+    jest.clearAllMocks();
+    mockJwtService.sign.mockReturnValue('mock.token');
+  });
+
+  describe('signup', () => {
+    const dto = {
+      email: 'test@example.com',
+      name: 'Test',
+      password: 'Password1!',
+      passwordConfirm: 'Password1!',
+      birthDate: '1990-01-01',
+      countryCode: 'KR',
+      phoneNumber: '+821012345678',
+    };
+
+    it('정상 회원가입 → bcrypt 해시 후 create 호출', async () => {
+      mockedBcrypt.hash.mockResolvedValue('hashed' as never);
+      mockUsersService.create.mockResolvedValue(mockUser);
+
+      await service.signup(dto);
+
+      expect(bcrypt.hash).toHaveBeenCalledWith(dto.password, 12);
+      expect(mockUsersService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ email: dto.email, password: 'hashed' }),
+      );
+    });
+
+    it('비밀번호 불일치 → BadRequestException', async () => {
+      await expect(service.signup({ ...dto, passwordConfirm: 'WrongPass1!' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('login', () => {
+    it('정상 로그인 → accessToken/refreshToken 반환', async () => {
+      mockUsersService.findByEmailWithPassword.mockResolvedValue(mockUser);
+      mockedBcrypt.compare.mockResolvedValue(true as never);
+      mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
+
+      const result = await service.login('test@example.com', 'Password1!');
+
+      expect(result.accessToken).toBeTruthy();
+      expect(result.refreshToken).toBeTruthy();
+      expect(result.user.email).toBe('test@example.com');
+    });
+
+    it('존재하지 않는 이메일 → NotFoundException', async () => {
+      mockUsersService.findByEmailWithPassword.mockResolvedValue(null);
+
+      await expect(service.login('none@example.com', 'Password1!')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('소셜 로그인 계정(password null) → BadRequestException', async () => {
+      mockUsersService.findByEmailWithPassword.mockResolvedValue({ ...mockUser, password: null });
+
+      await expect(service.login('test@example.com', 'Password1!')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('잘못된 비밀번호 → UnauthorizedException', async () => {
+      mockUsersService.findByEmailWithPassword.mockResolvedValue(mockUser);
+      mockedBcrypt.compare.mockResolvedValue(false as never);
+
+      await expect(service.login('test@example.com', 'WrongPass!')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('logout', () => {
+    it('refreshToken null로 업데이트', async () => {
+      mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
+
+      await service.logout(1);
+
+      expect(mockUsersService.updateRefreshToken).toHaveBeenCalledWith(1, null);
+    });
+  });
+
+  describe('refresh', () => {
+    it('유효한 토큰 → 새 토큰 반환 및 rotation', async () => {
+      mockJwtService.verify.mockReturnValue({ sub: 1, email: 'test@example.com' });
+      mockUsersService.findByIdWithRefreshToken.mockResolvedValue(mockUser);
+      mockedBcrypt.compare.mockResolvedValue(true as never);
+      mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
+
+      const result = await service.refresh('valid.refresh.token');
+
+      expect(result.accessToken).toBeTruthy();
+      expect(mockUsersService.updateRefreshToken).toHaveBeenCalled();
+    });
+
+    it('JWT 검증 실패 → UnauthorizedException', async () => {
+      mockJwtService.verify.mockImplementation(() => {
+        throw new Error('invalid');
+      });
+
+      await expect(service.refresh('bad.token')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('refreshToken bcrypt 불일치 → UnauthorizedException', async () => {
+      mockJwtService.verify.mockReturnValue({ sub: 1, email: 'test@example.com' });
+      mockUsersService.findByIdWithRefreshToken.mockResolvedValue(mockUser);
+      mockedBcrypt.compare.mockResolvedValue(false as never);
+
+      await expect(service.refresh('wrong.refresh.token')).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('checkEmail', () => {
+    it('미존재 이메일 → available: true', async () => {
+      mockUsersService.existsByEmail.mockResolvedValue(false);
+      expect((await service.checkEmail('new@example.com')).available).toBe(true);
+    });
+
+    it('존재 이메일 → available: false', async () => {
+      mockUsersService.existsByEmail.mockResolvedValue(true);
+      expect((await service.checkEmail('existing@example.com')).available).toBe(false);
+    });
+  });
+
+  describe('changePassword', () => {
+    const dto = {
+      currentPassword: 'OldPass1!',
+      newPassword: 'NewPass1!',
+      newPasswordConfirm: 'NewPass1!',
+    };
+
+    it('정상 변경', async () => {
+      mockUsersService.findByIdWithPassword.mockResolvedValue(mockUser);
+      mockedBcrypt.compare.mockResolvedValue(true as never);
+      mockedBcrypt.hash.mockResolvedValue('newHashed' as never);
+      mockUsersService.updatePassword.mockResolvedValue(undefined);
+
+      await service.changePassword(1, dto);
+
+      expect(mockUsersService.updatePassword).toHaveBeenCalledWith(1, 'newHashed');
+    });
+
+    it('새 비밀번호 불일치 → BadRequestException', async () => {
+      await expect(
+        service.changePassword(1, { ...dto, newPasswordConfirm: 'DiffPass1!' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('소셜 로그인 계정 → BadRequestException', async () => {
+      mockUsersService.findByIdWithPassword.mockResolvedValue({ ...mockUser, password: null });
+
+      await expect(service.changePassword(1, dto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('현재 비밀번호 불일치 → UnauthorizedException', async () => {
+      mockUsersService.findByIdWithPassword.mockResolvedValue(mockUser);
+      mockedBcrypt.compare.mockResolvedValue(false as never);
+
+      await expect(service.changePassword(1, dto)).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('adminLogin', () => {
+    it('정상 관리자 로그인', async () => {
+      const adminUser = { ...mockUser, role: UserRole.ADMIN };
+      mockUsersService.findByEmailWithPassword.mockResolvedValue(adminUser);
+      mockedBcrypt.compare.mockResolvedValue(true as never);
+      mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
+
+      const result = await service.adminLogin('admin@example.com', 'AdminPass1!');
+
+      expect(result.accessToken).toBeTruthy();
+    });
+
+    it('유저 없음 → DUMMY_HASH 비교 실행 후 UnauthorizedException', async () => {
+      mockUsersService.findByEmailWithPassword.mockResolvedValue(null);
+      const compareSpy = mockedBcrypt.compare.mockResolvedValue(false as never);
+
+      await expect(service.adminLogin('none@example.com', 'Pass1!')).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(compareSpy).toHaveBeenCalled();
+    });
+
+    it('ADMIN 아닌 사용자 → ForbiddenException', async () => {
+      mockUsersService.findByEmailWithPassword.mockResolvedValue(mockUser);
+      mockedBcrypt.compare.mockResolvedValue(true as never);
+
+      await expect(service.adminLogin('test@example.com', 'Pass1!')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('소셜 로그인 계정 → UnauthorizedException', async () => {
+      mockUsersService.findByEmailWithPassword.mockResolvedValue({ ...mockUser, password: null });
+
+      await expect(service.adminLogin('test@example.com', 'Pass1!')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('appleLogin', () => {
+    it('기존 Apple ID 유저 → isNewUser: false', async () => {
+      mockUsersService.findByAppleId.mockResolvedValue(mockUser);
+      mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
+
+      const result = await service.appleLogin('apple123', null, null);
+
+      expect(result.isNewUser).toBe(false);
+    });
+
+    it('기존 이메일 유저 → Apple ID 연동 후 isNewUser: false', async () => {
+      mockUsersService.findByAppleId.mockResolvedValue(null);
+      mockUsersService.findByEmail.mockResolvedValue(mockUser);
+      mockUsersService.linkAppleId.mockResolvedValue(undefined);
+      mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
+
+      const result = await service.appleLogin('apple123', 'test@example.com', 'Test');
+
+      expect(mockUsersService.linkAppleId).toHaveBeenCalledWith(1, 'apple123');
+      expect(result.isNewUser).toBe(false);
+    });
+
+    it('신규 유저 → 생성 후 isNewUser: true', async () => {
+      mockUsersService.findByAppleId.mockResolvedValue(null);
+      mockUsersService.findByEmail.mockResolvedValue(null);
+      mockUsersService.createAppleUser.mockResolvedValue(mockUser);
+      mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
+
+      const result = await service.appleLogin('apple123', 'new@example.com', 'New User');
+
+      expect(result.isNewUser).toBe(true);
+    });
+
+    it('최초 로그인에 email/name 없음 → BadRequestException', async () => {
+      mockUsersService.findByAppleId.mockResolvedValue(null);
+
+      await expect(service.appleLogin('apple123', null, null)).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/src/auth/guards/roles.guard.spec.ts
+++ b/src/auth/guards/roles.guard.spec.ts
@@ -8,7 +8,8 @@ const createMockContext = (userRole?: UserRole): ExecutionContext =>
     getHandler: jest.fn(),
     getClass: jest.fn(),
     switchToHttp: () => ({
-      getRequest: () => (userRole ? { user: { role: userRole } } : { user: undefined }),
+      getRequest: () =>
+        userRole ? { user: { role: userRole } } : { user: undefined },
     }),
   }) as unknown as ExecutionContext;
 
@@ -17,7 +18,9 @@ describe('RolesGuard', () => {
   let reflector: jest.Mocked<Reflector>;
 
   beforeEach(() => {
-    reflector = { getAllAndOverride: jest.fn() } as unknown as jest.Mocked<Reflector>;
+    reflector = {
+      getAllAndOverride: jest.fn(),
+    } as unknown as jest.Mocked<Reflector>;
     guard = new RolesGuard(reflector);
   });
 
@@ -36,12 +39,16 @@ describe('RolesGuard', () => {
   it('역할 불일치 (USER → ADMIN 필요) → ForbiddenException', () => {
     reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
 
-    expect(() => guard.canActivate(createMockContext(UserRole.USER))).toThrow(ForbiddenException);
+    expect(() => guard.canActivate(createMockContext(UserRole.USER))).toThrow(
+      ForbiddenException,
+    );
   });
 
   it('user 없음 → ForbiddenException', () => {
     reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
 
-    expect(() => guard.canActivate(createMockContext())).toThrow(ForbiddenException);
+    expect(() => guard.canActivate(createMockContext())).toThrow(
+      ForbiddenException,
+    );
   });
 });

--- a/src/auth/guards/roles.guard.spec.ts
+++ b/src/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,47 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserRole } from '@prisma/client';
+import { RolesGuard } from './roles.guard';
+
+const createMockContext = (userRole?: UserRole): ExecutionContext =>
+  ({
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: () => ({
+      getRequest: () => (userRole ? { user: { role: userRole } } : { user: undefined }),
+    }),
+  }) as unknown as ExecutionContext;
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: jest.Mocked<Reflector>;
+
+  beforeEach(() => {
+    reflector = { getAllAndOverride: jest.fn() } as unknown as jest.Mocked<Reflector>;
+    guard = new RolesGuard(reflector);
+  });
+
+  it('requiredRoles 없음 → true 반환', () => {
+    reflector.getAllAndOverride.mockReturnValue(undefined);
+
+    expect(guard.canActivate(createMockContext())).toBe(true);
+  });
+
+  it('역할 일치 (ADMIN) → true 반환', () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
+
+    expect(guard.canActivate(createMockContext(UserRole.ADMIN))).toBe(true);
+  });
+
+  it('역할 불일치 (USER → ADMIN 필요) → ForbiddenException', () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
+
+    expect(() => guard.canActivate(createMockContext(UserRole.USER))).toThrow(ForbiddenException);
+  });
+
+  it('user 없음 → ForbiddenException', () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
+
+    expect(() => guard.canActivate(createMockContext())).toThrow(ForbiddenException);
+  });
+});

--- a/src/encyclopedia/encyclopedia.service.spec.ts
+++ b/src/encyclopedia/encyclopedia.service.spec.ts
@@ -50,7 +50,12 @@ describe('EncyclopediaService', () => {
     await service.getTopics('Burns', 0, 50);
 
     expect(mockPrisma.healthTopic.count).toHaveBeenCalledWith({
-      where: { OR: expect.arrayContaining([expect.objectContaining({ title: expect.anything() })]) },
+      where: {
+        OR: [
+          { title: { contains: 'Burns' } },
+          { altTitles: { contains: 'Burns' } },
+        ],
+      },
     });
   });
 

--- a/src/encyclopedia/encyclopedia.service.spec.ts
+++ b/src/encyclopedia/encyclopedia.service.spec.ts
@@ -1,0 +1,75 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EncyclopediaService } from './encyclopedia.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+const mockPrisma = {
+  healthTopic: {
+    count: jest.fn(),
+    findMany: jest.fn(),
+  },
+};
+
+const rawTopic = {
+  id: 1,
+  title: 'Burns',
+  altTitles: '["Chemical Burns","Thermal Burns"]',
+  summary: 'Burns are caused by heat.',
+  categories: '["Injuries"]',
+  url: 'https://medlineplus.gov/burns.html',
+};
+
+describe('EncyclopediaService', () => {
+  let service: EncyclopediaService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EncyclopediaService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<EncyclopediaService>(EncyclopediaService);
+    jest.clearAllMocks();
+  });
+
+  it('search 없음 → where: {} 조건으로 전체 조회', async () => {
+    mockPrisma.healthTopic.count.mockResolvedValue(1);
+    mockPrisma.healthTopic.findMany.mockResolvedValue([rawTopic]);
+
+    const result = await service.getTopics(undefined, 0, 50);
+
+    expect(result.total).toBe(1);
+    expect(mockPrisma.healthTopic.count).toHaveBeenCalledWith({ where: {} });
+  });
+
+  it('search 있음 → OR 조건 포함', async () => {
+    mockPrisma.healthTopic.count.mockResolvedValue(1);
+    mockPrisma.healthTopic.findMany.mockResolvedValue([rawTopic]);
+
+    await service.getTopics('Burns', 0, 50);
+
+    expect(mockPrisma.healthTopic.count).toHaveBeenCalledWith({
+      where: { OR: expect.arrayContaining([expect.objectContaining({ title: expect.anything() })]) },
+    });
+  });
+
+  it('altTitles JSON 문자열 → 배열로 파싱', async () => {
+    mockPrisma.healthTopic.count.mockResolvedValue(1);
+    mockPrisma.healthTopic.findMany.mockResolvedValue([rawTopic]);
+
+    const result = await service.getTopics();
+
+    expect(Array.isArray(result.items[0].altTitles)).toBe(true);
+    expect(result.items[0].altTitles).toContain('Chemical Burns');
+  });
+
+  it('categories JSON 문자열 → 배열로 파싱', async () => {
+    mockPrisma.healthTopic.count.mockResolvedValue(1);
+    mockPrisma.healthTopic.findMany.mockResolvedValue([rawTopic]);
+
+    const result = await service.getTopics();
+
+    expect(Array.isArray(result.items[0].categories)).toBe(true);
+  });
+});

--- a/src/first-aid/first-aid.service.spec.ts
+++ b/src/first-aid/first-aid.service.spec.ts
@@ -20,7 +20,12 @@ const mockAiResult = {
   blogLinks: [],
 };
 
-const mockEmergencyContact = { fire: '119', police: '112', medical: '119', general: '112' };
+const mockEmergencyContact = {
+  fire: '119',
+  police: '112',
+  medical: '119',
+  general: '112',
+};
 
 describe('FirstAidService', () => {
   let service: FirstAidService;
@@ -30,7 +35,10 @@ describe('FirstAidService', () => {
       providers: [
         FirstAidService,
         { provide: GeocodingService, useValue: mockGeocodingService },
-        { provide: EmergencyContactService, useValue: mockEmergencyContactService },
+        {
+          provide: EmergencyContactService,
+          useValue: mockEmergencyContactService,
+        },
         { provide: OpenAiService, useValue: mockOpenAiService },
         { provide: EventEmitter2, useValue: mockEventEmitter },
       ],
@@ -39,8 +47,13 @@ describe('FirstAidService', () => {
     service = module.get<FirstAidService>(FirstAidService);
     jest.clearAllMocks();
 
-    mockGeocodingService.getCountryInfo.mockResolvedValue({ countryCode: 'KR', countryName: 'South Korea' });
-    mockEmergencyContactService.getContacts.mockReturnValue(mockEmergencyContact);
+    mockGeocodingService.getCountryInfo.mockResolvedValue({
+      countryCode: 'KR',
+      countryName: 'South Korea',
+    });
+    mockEmergencyContactService.getContacts.mockReturnValue(
+      mockEmergencyContact,
+    );
     mockOpenAiService.getAdvice.mockResolvedValue(mockAiResult);
   });
 
@@ -56,7 +69,9 @@ describe('FirstAidService', () => {
 
     expect(result.content).toBe(mockAiResult.content);
     expect(result.identificationResponse.countryCode).toBe('KR');
-    expect(result.identificationResponse.emergencyContact).toEqual(mockEmergencyContact);
+    expect(result.identificationResponse.emergencyContact).toEqual(
+      mockEmergencyContact,
+    );
   });
 
   it('userId 있음 → 이벤트 payload에 userId 포함', async () => {
@@ -78,7 +93,10 @@ describe('FirstAidService', () => {
   });
 
   it('geocoding UNKNOWN 반환 → 정상 응답 (fallback)', async () => {
-    mockGeocodingService.getCountryInfo.mockResolvedValue({ countryCode: 'UNKNOWN', countryName: 'Unknown' });
+    mockGeocodingService.getCountryInfo.mockResolvedValue({
+      countryCode: 'UNKNOWN',
+      countryName: 'Unknown',
+    });
 
     const result = await service.getAdvice(dto);
 

--- a/src/first-aid/first-aid.service.spec.ts
+++ b/src/first-aid/first-aid.service.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { FirstAidService } from './first-aid.service';
+import { GeocodingService } from './services/geocoding.service';
+import { EmergencyContactService } from './services/emergency-contact.service';
+import { OpenAiService } from './services/openai.service';
+import { SymptomType } from './dto/advice-request.dto';
+
+const mockGeocodingService = { getCountryInfo: jest.fn() };
+const mockEmergencyContactService = { getContacts: jest.fn() };
+const mockOpenAiService = { getAdvice: jest.fn() };
+const mockEventEmitter = { emit: jest.fn() };
+
+const mockAiResult = {
+  content: '압박 지혈을 하세요',
+  summary: '직접 압박',
+  recommendedAction: '119 신고',
+  disclaimer: 'AI 조언입니다',
+  confidence: 85,
+  blogLinks: [],
+};
+
+const mockEmergencyContact = { fire: '119', police: '112', medical: '119', general: '112' };
+
+describe('FirstAidService', () => {
+  let service: FirstAidService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FirstAidService,
+        { provide: GeocodingService, useValue: mockGeocodingService },
+        { provide: EmergencyContactService, useValue: mockEmergencyContactService },
+        { provide: OpenAiService, useValue: mockOpenAiService },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
+      ],
+    }).compile();
+
+    service = module.get<FirstAidService>(FirstAidService);
+    jest.clearAllMocks();
+
+    mockGeocodingService.getCountryInfo.mockResolvedValue({ countryCode: 'KR', countryName: 'South Korea' });
+    mockEmergencyContactService.getContacts.mockReturnValue(mockEmergencyContact);
+    mockOpenAiService.getAdvice.mockResolvedValue(mockAiResult);
+  });
+
+  const dto = {
+    symptomType: SymptomType.BLEEDING,
+    symptomDetail: '손가락에서 피가 많이 납니다.',
+    latitude: 37.5665,
+    longitude: 126.978,
+  };
+
+  it('정상 요청 → 응답 구조 반환', async () => {
+    const result = await service.getAdvice(dto);
+
+    expect(result.content).toBe(mockAiResult.content);
+    expect(result.identificationResponse.countryCode).toBe('KR');
+    expect(result.identificationResponse.emergencyContact).toEqual(mockEmergencyContact);
+  });
+
+  it('userId 있음 → 이벤트 payload에 userId 포함', async () => {
+    await service.getAdvice(dto, 42);
+
+    expect(mockEventEmitter.emit).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ userId: 42 }),
+    );
+  });
+
+  it('userId 없음 → 이벤트 payload에 userId undefined', async () => {
+    await service.getAdvice(dto);
+
+    expect(mockEventEmitter.emit).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ userId: undefined }),
+    );
+  });
+
+  it('geocoding UNKNOWN 반환 → 정상 응답 (fallback)', async () => {
+    mockGeocodingService.getCountryInfo.mockResolvedValue({ countryCode: 'UNKNOWN', countryName: 'Unknown' });
+
+    const result = await service.getAdvice(dto);
+
+    expect(result.identificationResponse.countryCode).toBe('UNKNOWN');
+    expect(result.content).toBeTruthy();
+  });
+
+  it('이벤트는 fire-and-forget (await 없이 emit 호출)', async () => {
+    await service.getAdvice(dto);
+
+    expect(mockEventEmitter.emit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/first-aid/listeners/first-aid-log.listener.spec.ts
+++ b/src/first-aid/listeners/first-aid-log.listener.spec.ts
@@ -1,34 +1,35 @@
 import { FirstAidLogListener } from './first-aid-log.listener';
 import { PrismaService } from '../../prisma/prisma.service';
-import { FirstAidAdviceCompletedEvent, FIRST_AID_ADVICE_COMPLETED } from '../events/first-aid.events';
+import { FirstAidAdviceCompletedEvent } from '../events/first-aid.events';
 import { SymptomType } from '@prisma/client';
+
+const makeEvent = (userId?: number): FirstAidAdviceCompletedEvent => {
+  const event = new FirstAidAdviceCompletedEvent();
+  event.userId = userId;
+  event.symptomType = SymptomType.BLEEDING;
+  event.countryCode = 'KR';
+  event.confidence = 85;
+  return event;
+};
 
 describe('FirstAidLogListener', () => {
   let listener: FirstAidLogListener;
-  let prisma: jest.Mocked<Pick<PrismaService, 'firstAidLog'>>;
+  let createFn: jest.Mock;
 
   beforeEach(() => {
-    prisma = {
-      firstAidLog: { create: jest.fn() },
-    } as unknown as jest.Mocked<Pick<PrismaService, 'firstAidLog'>>;
-    listener = new FirstAidLogListener(prisma as unknown as PrismaService);
+    createFn = jest.fn();
+    const prisma = {
+      firstAidLog: { create: createFn },
+    } as unknown as PrismaService;
+    listener = new FirstAidLogListener(prisma);
   });
 
-  const makeEvent = (userId?: number): FirstAidAdviceCompletedEvent => {
-    const event = new FirstAidAdviceCompletedEvent();
-    event.userId = userId;
-    event.symptomType = SymptomType.BLEEDING;
-    event.countryCode = 'KR';
-    event.confidence = 85;
-    return event;
-  };
-
   it('정상 이벤트 → firstAidLog.create 호출', async () => {
-    (prisma.firstAidLog.create as jest.Mock).mockResolvedValue({});
+    createFn.mockResolvedValue({});
 
     await listener.handleAdviceCompleted(makeEvent(1));
 
-    expect(prisma.firstAidLog.create).toHaveBeenCalledWith({
+    expect(createFn).toHaveBeenCalledWith({
       data: {
         userId: 1,
         symptomType: SymptomType.BLEEDING,
@@ -39,18 +40,29 @@ describe('FirstAidLogListener', () => {
   });
 
   it('userId 없는 이벤트 → userId: null 저장', async () => {
-    (prisma.firstAidLog.create as jest.Mock).mockResolvedValue({});
+    createFn.mockResolvedValue({});
 
     await listener.handleAdviceCompleted(makeEvent(undefined));
 
-    expect(prisma.firstAidLog.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({ userId: null }),
+    expect(createFn).toHaveBeenCalledWith({
+      data: {
+        userId: null,
+        symptomType: SymptomType.BLEEDING,
+        countryCode: 'KR',
+        confidence: 85,
+      },
     });
   });
 
-  it('DB 저장 실패 → 예외 throw 없이 에러 로그만', async () => {
-    (prisma.firstAidLog.create as jest.Mock).mockRejectedValue(new Error('DB Error'));
+  it('DB 저장 실패 → 예외 throw 없이 처리', async () => {
+    createFn.mockRejectedValue(new Error('DB Error'));
 
-    await expect(listener.handleAdviceCompleted(makeEvent(1))).resolves.not.toThrow();
+    let threw = false;
+    try {
+      await listener.handleAdviceCompleted(makeEvent(1));
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
   });
 });

--- a/src/first-aid/listeners/first-aid-log.listener.spec.ts
+++ b/src/first-aid/listeners/first-aid-log.listener.spec.ts
@@ -1,0 +1,56 @@
+import { FirstAidLogListener } from './first-aid-log.listener';
+import { PrismaService } from '../../prisma/prisma.service';
+import { FirstAidAdviceCompletedEvent, FIRST_AID_ADVICE_COMPLETED } from '../events/first-aid.events';
+import { SymptomType } from '@prisma/client';
+
+describe('FirstAidLogListener', () => {
+  let listener: FirstAidLogListener;
+  let prisma: jest.Mocked<Pick<PrismaService, 'firstAidLog'>>;
+
+  beforeEach(() => {
+    prisma = {
+      firstAidLog: { create: jest.fn() },
+    } as unknown as jest.Mocked<Pick<PrismaService, 'firstAidLog'>>;
+    listener = new FirstAidLogListener(prisma as unknown as PrismaService);
+  });
+
+  const makeEvent = (userId?: number): FirstAidAdviceCompletedEvent => {
+    const event = new FirstAidAdviceCompletedEvent();
+    event.userId = userId;
+    event.symptomType = SymptomType.BLEEDING;
+    event.countryCode = 'KR';
+    event.confidence = 85;
+    return event;
+  };
+
+  it('정상 이벤트 → firstAidLog.create 호출', async () => {
+    (prisma.firstAidLog.create as jest.Mock).mockResolvedValue({});
+
+    await listener.handleAdviceCompleted(makeEvent(1));
+
+    expect(prisma.firstAidLog.create).toHaveBeenCalledWith({
+      data: {
+        userId: 1,
+        symptomType: SymptomType.BLEEDING,
+        countryCode: 'KR',
+        confidence: 85,
+      },
+    });
+  });
+
+  it('userId 없는 이벤트 → userId: null 저장', async () => {
+    (prisma.firstAidLog.create as jest.Mock).mockResolvedValue({});
+
+    await listener.handleAdviceCompleted(makeEvent(undefined));
+
+    expect(prisma.firstAidLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ userId: null }),
+    });
+  });
+
+  it('DB 저장 실패 → 예외 throw 없이 에러 로그만', async () => {
+    (prisma.firstAidLog.create as jest.Mock).mockRejectedValue(new Error('DB Error'));
+
+    await expect(listener.handleAdviceCompleted(makeEvent(1))).resolves.not.toThrow();
+  });
+});

--- a/src/first-aid/services/emergency-contact.service.spec.ts
+++ b/src/first-aid/services/emergency-contact.service.spec.ts
@@ -1,0 +1,33 @@
+import { EmergencyContactService } from './emergency-contact.service';
+
+describe('EmergencyContactService', () => {
+  let service: EmergencyContactService;
+
+  beforeEach(() => {
+    service = new EmergencyContactService();
+  });
+
+  it('등록된 국가코드(KR) → 한국 응급번호 반환', () => {
+    const result = service.getContacts('KR');
+    expect(result.police).toBe('112');
+    expect(result.medical).toBe('119');
+    expect(result.fire).toBe('119');
+  });
+
+  it('등록된 국가코드(US) → 미국 응급번호 반환', () => {
+    const result = service.getContacts('US');
+    expect(result.general).toBe('911');
+  });
+
+  it('미등록 국가코드 → DEFAULT 반환', () => {
+    const result = service.getContacts('XX');
+    expect(result).toBeDefined();
+    expect(result.general).toBeTruthy();
+  });
+
+  it('UNKNOWN → DEFAULT 반환', () => {
+    const result = service.getContacts('UNKNOWN');
+    expect(result).toBeDefined();
+    expect(result.general).toBeTruthy();
+  });
+});

--- a/src/first-aid/services/geocoding.service.spec.ts
+++ b/src/first-aid/services/geocoding.service.spec.ts
@@ -1,0 +1,43 @@
+import { GeocodingService } from './geocoding.service';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('GeocodingService', () => {
+  let service: GeocodingService;
+
+  beforeEach(() => {
+    service = new GeocodingService();
+    jest.clearAllMocks();
+  });
+
+  it('정상 응답 → countryCode/countryName 반환', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: { countryCode: 'KR', countryName: 'South Korea' },
+    });
+
+    const result = await service.getCountryInfo(37.5665, 126.978);
+
+    expect(result.countryCode).toBe('KR');
+    expect(result.countryName).toBe('South Korea');
+  });
+
+  it('countryCode 없는 응답 → UNKNOWN fallback', async () => {
+    mockedAxios.get.mockResolvedValue({ data: {} });
+
+    const result = await service.getCountryInfo(0, 0);
+
+    expect(result.countryCode).toBe('UNKNOWN');
+    expect(result.countryName).toBe('Unknown');
+  });
+
+  it('axios 실패 → 예외 없이 UNKNOWN 반환', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('Network Error'));
+
+    const result = await service.getCountryInfo(37.5665, 126.978);
+
+    expect(result.countryCode).toBe('UNKNOWN');
+    expect(result.countryName).toBe('Unknown');
+  });
+});

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -84,9 +84,11 @@ describe('UsersService', () => {
 
       await service.updateRefreshToken(1, 'raw_token');
 
-      const call = mockPrisma.user.update.mock.calls[0][0] as { data: { refreshToken: string } };
-      expect(call.data.refreshToken).not.toBe('raw_token');
-      expect(call.data.refreshToken).toBeTruthy();
+      const calls = mockPrisma.user.update.mock.calls as Array<
+        [{ data: { refreshToken: string } }]
+      >;
+      expect(calls[0][0].data.refreshToken).not.toBe('raw_token');
+      expect(calls[0][0].data.refreshToken).toBeTruthy();
     });
 
     it('null → bcrypt 없이 null 저장', async () => {
@@ -94,8 +96,10 @@ describe('UsersService', () => {
 
       await service.updateRefreshToken(1, null);
 
-      const call = mockPrisma.user.update.mock.calls[0][0] as { data: { refreshToken: null } };
-      expect(call.data.refreshToken).toBeNull();
+      const calls = mockPrisma.user.update.mock.calls as Array<
+        [{ data: { refreshToken: null } }]
+      >;
+      expect(calls[0][0].data.refreshToken).toBeNull();
     });
   });
 
@@ -113,7 +117,11 @@ describe('UsersService', () => {
 
   describe('createGoogleUser', () => {
     it('provider: GOOGLE, password: null 로 생성', async () => {
-      mockPrisma.user.create.mockResolvedValue({ ...mockUser, provider: Provider.GOOGLE, password: null });
+      mockPrisma.user.create.mockResolvedValue({
+        ...mockUser,
+        provider: Provider.GOOGLE,
+        password: null,
+      });
 
       await service.createGoogleUser({
         email: 'test@example.com',
@@ -125,21 +133,33 @@ describe('UsersService', () => {
         phoneNumber: '+821012345678',
       });
 
-      const call = mockPrisma.user.create.mock.calls[0][0] as { data: { provider: Provider; password: null } };
-      expect(call.data.provider).toBe(Provider.GOOGLE);
-      expect(call.data.password).toBeNull();
+      const calls = mockPrisma.user.create.mock.calls as Array<
+        [{ data: { provider: Provider; password: null } }]
+      >;
+      expect(calls[0][0].data.provider).toBe(Provider.GOOGLE);
+      expect(calls[0][0].data.password).toBeNull();
     });
   });
 
   describe('createAppleUser', () => {
     it('provider: APPLE, password: null 로 생성', async () => {
-      mockPrisma.user.create.mockResolvedValue({ ...mockUser, provider: Provider.APPLE, password: null });
+      mockPrisma.user.create.mockResolvedValue({
+        ...mockUser,
+        provider: Provider.APPLE,
+        password: null,
+      });
 
-      await service.createAppleUser({ appleId: 'apple123', email: 'test@example.com', name: 'Test' });
+      await service.createAppleUser({
+        appleId: 'apple123',
+        email: 'test@example.com',
+        name: 'Test',
+      });
 
-      const call = mockPrisma.user.create.mock.calls[0][0] as { data: { provider: Provider; password: null } };
-      expect(call.data.provider).toBe(Provider.APPLE);
-      expect(call.data.password).toBeNull();
+      const calls = mockPrisma.user.create.mock.calls as Array<
+        [{ data: { provider: Provider; password: null } }]
+      >;
+      expect(calls[0][0].data.provider).toBe(Provider.APPLE);
+      expect(calls[0][0].data.password).toBeNull();
     });
   });
 

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException } from '@nestjs/common';
+import { Prisma, Provider } from '@prisma/client';
+import { UsersService } from './users.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+const mockPrisma = {
+  user: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    count: jest.fn(),
+    findMany: jest.fn(),
+  },
+  $transaction: jest.fn(),
+};
+
+const mockUser = {
+  id: 1,
+  email: 'test@example.com',
+  name: 'Test User',
+  password: 'hashed',
+  provider: Provider.LOCAL,
+  role: 'USER',
+  refreshToken: 'hashed_refresh',
+  googleId: null,
+  appleId: null,
+  birthDate: '1990-01-01',
+  countryCode: 'KR',
+  phoneNumber: '+821012345678',
+  profileImageUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    const data = {
+      email: 'test@example.com',
+      name: 'Test',
+      password: 'hashed',
+      birthDate: '1990-01-01',
+      countryCode: 'KR',
+      phoneNumber: '+821012345678',
+    };
+
+    it('정상 생성', async () => {
+      mockPrisma.user.create.mockResolvedValue(mockUser);
+
+      const result = await service.create(data);
+
+      expect(result).toEqual(mockUser);
+      expect(mockPrisma.user.create).toHaveBeenCalledWith({ data });
+    });
+
+    it('이메일 중복(P2002) → ConflictException', async () => {
+      const prismaError = new Prisma.PrismaClientKnownRequestError('', {
+        code: 'P2002',
+        clientVersion: '5.0',
+      });
+      mockPrisma.user.create.mockRejectedValue(prismaError);
+
+      await expect(service.create(data)).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('updateRefreshToken', () => {
+    it('token 있음 → bcrypt 해시 후 저장', async () => {
+      mockPrisma.user.update.mockResolvedValue({});
+
+      await service.updateRefreshToken(1, 'raw_token');
+
+      const call = mockPrisma.user.update.mock.calls[0][0] as { data: { refreshToken: string } };
+      expect(call.data.refreshToken).not.toBe('raw_token');
+      expect(call.data.refreshToken).toBeTruthy();
+    });
+
+    it('null → bcrypt 없이 null 저장', async () => {
+      mockPrisma.user.update.mockResolvedValue({});
+
+      await service.updateRefreshToken(1, null);
+
+      const call = mockPrisma.user.update.mock.calls[0][0] as { data: { refreshToken: null } };
+      expect(call.data.refreshToken).toBeNull();
+    });
+  });
+
+  describe('existsByEmail', () => {
+    it('존재 → true', async () => {
+      mockPrisma.user.count.mockResolvedValue(1);
+      expect(await service.existsByEmail('test@example.com')).toBe(true);
+    });
+
+    it('미존재 → false', async () => {
+      mockPrisma.user.count.mockResolvedValue(0);
+      expect(await service.existsByEmail('none@example.com')).toBe(false);
+    });
+  });
+
+  describe('createGoogleUser', () => {
+    it('provider: GOOGLE, password: null 로 생성', async () => {
+      mockPrisma.user.create.mockResolvedValue({ ...mockUser, provider: Provider.GOOGLE, password: null });
+
+      await service.createGoogleUser({
+        email: 'test@example.com',
+        name: 'Test',
+        googleId: 'google123',
+        profileImageUrl: null,
+        birthDate: '1990-01-01',
+        countryCode: 'KR',
+        phoneNumber: '+821012345678',
+      });
+
+      const call = mockPrisma.user.create.mock.calls[0][0] as { data: { provider: Provider; password: null } };
+      expect(call.data.provider).toBe(Provider.GOOGLE);
+      expect(call.data.password).toBeNull();
+    });
+  });
+
+  describe('createAppleUser', () => {
+    it('provider: APPLE, password: null 로 생성', async () => {
+      mockPrisma.user.create.mockResolvedValue({ ...mockUser, provider: Provider.APPLE, password: null });
+
+      await service.createAppleUser({ appleId: 'apple123', email: 'test@example.com', name: 'Test' });
+
+      const call = mockPrisma.user.create.mock.calls[0][0] as { data: { provider: Provider; password: null } };
+      expect(call.data.provider).toBe(Provider.APPLE);
+      expect(call.data.password).toBeNull();
+    });
+  });
+
+  describe('findAllPaginated', () => {
+    it('$transaction으로 users/total 동시 조회', async () => {
+      mockPrisma.$transaction.mockResolvedValue([[mockUser], 1]);
+
+      const result = await service.findAllPaginated(0, 10);
+
+      expect(result.total).toBe(1);
+      expect(result.users).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## 개요

핵심 비즈니스 로직에 대한 유닛 테스트를 작성했습니다. DB 없이 jest mock만으로 실행되며 기존 CI `pnpm test` 스텝에 자동 포함됩니다.

Closes #42

---

## 테스트 현황

| 파일 | 케이스 | 주요 검증 |
|---|---|---|
| `auth.service.spec.ts` | 20개 | 인증 전체 흐름, DUMMY_HASH 타이밍 공격 방어, OAuth 분기 |
| `users.service.spec.ts` | 9개 | P2002 중복 처리, refreshToken hash/null, OAuth 유저 생성 |
| `emergency-contact.service.spec.ts` | 4개 | 국가별 응급번호, UNKNOWN fallback |
| `geocoding.service.spec.ts` | 3개 | 정상/필드누락/axios 실패 fallback |
| `first-aid.service.spec.ts` | 5개 | 서비스 조합, 이벤트 emit, UNKNOWN fallback |
| `first-aid-log.listener.spec.ts` | 3개 | DB 저장, userId null, 실패 시 throw 없음 |
| `roles.guard.spec.ts` | 4개 | ADMIN/USER/미인증 접근 제어 |
| `encyclopedia.service.spec.ts` | 4개 | JSON→배열 파싱, search OR 조건 |
| **합계** | **56개** | |

---

## 설계 원칙

- **DB 없음** — PrismaService를 jest.fn() mock으로 대체, CI MySQL 불필요
- **외부 API 없음** — bcrypt, axios, OpenAI 모두 jest.mock()으로 모듈 레벨 mock
- **독립 실행** — 각 테스트가 beforeEach에서 mock 초기화, 순서 무관

## Test plan

- [ ] `pnpm test` 로컬 실행 → 56개 통과 확인
- [ ] CI `Test` 스텝 통과 확인