### PR TITLE
[FIX] Swagger 문서 프로덕션 환경 노출 방지

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,20 +34,22 @@ async function bootstrap() {
   app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalInterceptors(new ResponseInterceptor(app.get(Reflector)));
 
-  const swaggerConfig = new DocumentBuilder()
-    .setTitle('VitalTrip API')
-    .setDescription('VitalTrip 백엔드 API 문서')
-    .setVersion('1.0')
-    .addBearerAuth(
-      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
-      'access-token',
-    )
-    .build();
+  if (process.env.NODE_ENV !== 'production') {
+    const swaggerConfig = new DocumentBuilder()
+      .setTitle('VitalTrip API')
+      .setDescription('VitalTrip 백엔드 API 문서')
+      .setVersion('1.0')
+      .addBearerAuth(
+        { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+        'access-token',
+      )
+      .build();
 
-  const document = SwaggerModule.createDocument(app, swaggerConfig);
-  SwaggerModule.setup('docs', app, document, {
-    swaggerOptions: { persistAuthorization: true },
-  });
+    const document = SwaggerModule.createDocument(app, swaggerConfig);
+    SwaggerModule.setup('docs', app, document, {
+      swaggerOptions: { persistAuthorization: true },
+    });
+  }
 
   const port = process.env.PORT ?? 3000;
   await app.listen(port);


### PR DESCRIPTION
## Summary
- `NODE_ENV !== 'production'` 조건으로 Swagger 설정 블록을 감싸 프로덕션에서 `/docs` 비활성화

## 관련 이슈
Closes #44

## Test plan
- [ ] `NODE_ENV=production`으로 서버 실행 시 `/docs` 404 응답 확인
- [ ] `NODE_ENV=development`에서는 `/docs` 정상 접근 확인
- [ ] 빌드 및 테스트 통과 확인