### PR TITLE
[FIX] bcrypt salt rounds 12로 통일

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -4,6 +4,8 @@ import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../prisma/prisma.service';
 import { ErrorCode } from '../common/constants/error-codes';
 
+const SALT_ROUNDS = 12;
+
 @Injectable()
 export class UsersService {
   constructor(private readonly prisma: PrismaService) {}
@@ -65,7 +67,7 @@ export class UsersService {
   }
 
   async updateRefreshToken(id: number, refreshToken: string | null) {
-    const hashed = refreshToken ? await bcrypt.hash(refreshToken, 10) : null;
+    const hashed = refreshToken ? await bcrypt.hash(refreshToken, SALT_ROUNDS) : null;
     await this.prisma.user.update({
       where: { id },
       data: { refreshToken: hashed },


### PR DESCRIPTION
## Summary
- `users.service.ts`의 `updateRefreshToken`에서 하드코딩된 `10`을 `SALT_ROUNDS = 12` 상수로 교체
- `auth.service.ts`의 비밀번호 해싱과 동일한 강도로 통일

## 관련 이슈
Closes #45

## Test plan
- [ ] 로그인 → 리프레시 토큰 발급 정상 동작 확인
- [ ] 토큰 갱신(`/auth/refresh`) 정상 동작 확인
- [ ] 빌드 및 테스트 통과 확인