### PR TITLE
[REFACTOR] GooglePlacesService process.env → ConfigService 교체

### DIFF
--- a/src/location/services/google-places.service.ts
+++ b/src/location/services/google-places.service.ts
@@ -3,6 +3,7 @@ import {
   Logger,
   ServiceUnavailableException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
 import { ErrorCode } from '../../common/constants/error-codes';
 import { FacilityType } from '../dto/nearby-query.dto';
@@ -36,6 +37,8 @@ export class GooglePlacesService {
     { data: NearbyFacility[]; expiresAt: number }
   >();
 
+  constructor(private readonly config: ConfigService) {}
+
   async getNearbyFacilities(
     latitude: number,
     longitude: number,
@@ -49,7 +52,7 @@ export class GooglePlacesService {
       return cached.data;
     }
 
-    const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+    const apiKey = this.config.get<string>('GOOGLE_PLACES_API_KEY');
     if (!apiKey) {
       throw new ServiceUnavailableException({
         message: '주변 의료시설 검색 서비스를 일시적으로 사용할 수 없습니다.',


### PR DESCRIPTION
## Summary
- `google-places.service.ts`에서 `process.env.GOOGLE_PLACES_API_KEY` 직접 접근 제거
- `ConfigService` 주입 후 `this.config.get('GOOGLE_PLACES_API_KEY')`로 교체
- 모든 서비스가 동일한 방식으로 환경변수를 주입받도록 통일

## 관련 이슈
Closes #47

## Test plan
- [ ] `GET /api/location/nearby` 정상 동작 확인
- [ ] 빌드 및 테스트 통과 확인