### PR TITLE
[REFACTOR] refresh/adminRefresh 중복 로직 추출

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -106,35 +106,7 @@ export class AuthService {
   }
 
   async refresh(refreshToken: string) {
-    let payload: { sub: number; email: string };
-
-    try {
-      payload = this.jwtService.verify<{ sub: number; email: string }>(
-        refreshToken,
-        {
-          secret: this.config.get<string>('JWT_REFRESH_SECRET'),
-        },
-      );
-    } catch {
-      throw new UnauthorizedException({
-        message: '유효하지 않은 리프레시 토큰입니다.',
-        errorCode: ErrorCode.UNAUTHORIZED,
-      });
-    }
-
-    const user = await this.usersService.findByIdWithRefreshToken(payload.sub);
-    const tokenValid = user?.refreshToken
-      ? await bcrypt.compare(refreshToken, user.refreshToken)
-      : false;
-    if (!user || !tokenValid) {
-      throw new UnauthorizedException({
-        message: '유효하지 않은 리프레시 토큰입니다.',
-        errorCode: ErrorCode.UNAUTHORIZED,
-      });
-    }
-
-    const tokens = this.generateTokens(user.id, user.email);
-    await this.usersService.updateRefreshToken(user.id, tokens.refreshToken);
+    const { tokens } = await this.verifyAndRotateRefreshToken(refreshToken);
     return tokens;
   }
 
@@ -379,6 +351,20 @@ export class AuthService {
   async adminRefresh(
     refreshToken: string,
   ): Promise<{ accessToken: string; refreshToken: string }> {
+    const { user, tokens } =
+      await this.verifyAndRotateRefreshToken(refreshToken);
+
+    if (user.role !== UserRole.ADMIN) {
+      throw new ForbiddenException({
+        message: '관리자 권한이 필요합니다.',
+        errorCode: ErrorCode.FORBIDDEN,
+      });
+    }
+
+    return tokens;
+  }
+
+  private async verifyAndRotateRefreshToken(refreshToken: string) {
     let payload: { sub: number; email: string };
 
     try {
@@ -404,16 +390,9 @@ export class AuthService {
       });
     }
 
-    if (user.role !== UserRole.ADMIN) {
-      throw new ForbiddenException({
-        message: '관리자 권한이 필요합니다.',
-        errorCode: ErrorCode.FORBIDDEN,
-      });
-    }
-
     const tokens = this.generateTokens(user.id, user.email);
     await this.usersService.updateRefreshToken(user.id, tokens.refreshToken);
-    return tokens;
+    return { user, tokens };
   }
 
   private generateTokens(userId: number, email: string) {


### PR DESCRIPTION
## Summary
- `refresh`와 `adminRefresh`의 공통 로직(토큰 검증 → DB 조회 → 토큰 갱신)을 `verifyAndRotateRefreshToken` private 메서드로 추출
- `adminRefresh`는 공통 로직 호출 후 role 체크만 수행하도록 단순화

## 관련 이슈
Closes #48

## Test plan
- [ ] `POST /auth/refresh` 정상 동작 확인
- [ ] `POST /admin/auth/refresh` 정상 동작 확인
- [ ] 유효하지 않은 토큰 시 401 반환 확인
- [ ] 관리자가 아닌 유저로 adminRefresh 호출 시 403 반환 확인
- [ ] 빌드 및 테스트 통과 확인