### PR TITLE
[FEAT] Prometheus 및 Grafana 모니터링 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,32 @@ services:
     depends_on:
       - app
 
+  prometheus:
+    image: prom/prometheus:latest
+    restart: always
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - '9090:9090'
+    depends_on:
+      - app
+
+  grafana:
+    image: grafana/grafana:latest
+    restart: always
+    ports:
+      - '3001:3000'
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+
 volumes:
   mysql_data:
   qdrant_data:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'vitaltrip-server'
+    static_configs:
+      - targets: ['app:3000']
+    metrics_path: '/metrics'

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@prisma/client": "^5.22.0",
     "@qdrant/js-client-rest": "^1.13.0",
     "@types/cookie-parser": "^1.4.10",
+    "@willsoto/nestjs-prometheus": "^6.1.0",
     "axios": "^1.15.2",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
@@ -53,6 +54,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "prisma": "^5.22.0",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@types/cookie-parser':
         specifier: ^1.4.10
         version: 1.4.10(@types/express@5.0.6)
+      '@willsoto/nestjs-prometheus':
+        specifier: ^6.1.0
+        version: 6.1.0(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(prom-client@15.1.3)
       axios:
         specifier: ^1.15.2
         version: 1.15.2
@@ -74,6 +77,9 @@ importers:
       prisma:
         specifier: ^5.22.0
         version: 5.22.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -823,6 +829,10 @@ packages:
     engines: {node: ^14.18.0 || >=16.10.0, npm: '>=5.10.0'}
     hasBin: true
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
@@ -1217,6 +1227,12 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@willsoto/nestjs-prometheus@6.1.0':
+    resolution: {integrity: sha512-lrCEnJBBSzUIYWGR+PsZw1YXs1B9jzxFEuNAa3RzTxuFAFdI+sW7Fp52il/U/dX2MWoHc32x06OS0nm56QwyzQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      prom-client: ^15.0.0
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -1386,6 +1402,9 @@ packages:
   bcrypt@6.0.0:
     resolution: {integrity: sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==}
     engines: {node: '>= 18'}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -2749,6 +2768,10 @@ packages:
     engines: {node: '>=16.13'}
     hasBin: true
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -3003,6 +3026,9 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   terser-webpack-plugin@5.4.0:
     resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
@@ -4130,6 +4156,8 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -4580,6 +4608,11 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@willsoto/nestjs-prometheus@6.1.0(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(prom-client@15.1.3)':
+    dependencies:
+      '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      prom-client: 15.1.3
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -4749,6 +4782,8 @@ snapshots:
     dependencies:
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -6232,6 +6267,11 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -6501,6 +6541,10 @@ snapshots:
       '@pkgr/core': 0.2.9
 
   tapable@2.3.3: {}
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   terser-webpack-plugin@5.4.0(webpack@5.106.0):
     dependencies:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
+import { PrometheusModule } from '@willsoto/nestjs-prometheus';
 import { PrismaModule } from './prisma/prisma.module';
 import { FirstAidModule } from './first-aid/first-aid.module';
 import { EncyclopediaModule } from './encyclopedia/encyclopedia.module';
@@ -9,10 +10,20 @@ import { UsersModule } from './users/users.module';
 import { UserModule } from './user/user.module';
 import { LocationModule } from './location/location.module';
 import { AdminModule } from './admin/admin.module';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { LoggerMiddleware } from './common/middleware/logger.middleware';
+import { MetricsInterceptor } from './common/interceptors/metrics.interceptor';
+import {
+  makeCounterProvider,
+  makeHistogramProvider,
+} from '@willsoto/nestjs-prometheus';
 
 @Module({
   imports: [
+    PrometheusModule.register({
+      defaultMetrics: { enabled: true },
+      path: '/metrics',
+    }),
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: '.env',
@@ -26,6 +37,25 @@ import { LoggerMiddleware } from './common/middleware/logger.middleware';
     UserModule,
     LocationModule,
     AdminModule,
+  ],
+})
+  providers: [
+    makeHistogramProvider({
+      name: 'http_request_duration_seconds',
+      help: 'HTTP 요청 처리 시간 (초)',
+      labelNames: ['method', 'route', 'statusCode'],
+      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+    }),
+    makeCounterProvider({
+      name: 'http_requests_total',
+      help: 'HTTP 요청 총 수',
+      labelNames: ['method', 'route', 'statusCode'],
+    }),
+    MetricsInterceptor,
+    {
+      provide: APP_INTERCEPTOR,
+      useExisting: MetricsInterceptor,
+    },
   ],
 })
 export class AppModule implements NestModule {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,12 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
-import { PrometheusModule } from '@willsoto/nestjs-prometheus';
+import {
+  PrometheusModule,
+  makeCounterProvider,
+  makeHistogramProvider,
+} from '@willsoto/nestjs-prometheus';
 import { PrismaModule } from './prisma/prisma.module';
 import { FirstAidModule } from './first-aid/first-aid.module';
 import { EncyclopediaModule } from './encyclopedia/encyclopedia.module';
@@ -10,13 +15,8 @@ import { UsersModule } from './users/users.module';
 import { UserModule } from './user/user.module';
 import { LocationModule } from './location/location.module';
 import { AdminModule } from './admin/admin.module';
-import { APP_INTERCEPTOR } from '@nestjs/core';
 import { LoggerMiddleware } from './common/middleware/logger.middleware';
 import { MetricsInterceptor } from './common/interceptors/metrics.interceptor';
-import {
-  makeCounterProvider,
-  makeHistogramProvider,
-} from '@willsoto/nestjs-prometheus';
 
 @Module({
   imports: [
@@ -38,7 +38,6 @@ import {
     LocationModule,
     AdminModule,
   ],
-})
   providers: [
     makeHistogramProvider({
       name: 'http_request_duration_seconds',

--- a/src/common/interceptors/metrics.interceptor.ts
+++ b/src/common/interceptors/metrics.interceptor.ts
@@ -29,7 +29,8 @@ export class MetricsInterceptor implements NestInterceptor {
     }
 
     const method = req.method;
-    const route = (req.route?.path as string | undefined) ?? req.path;
+    const routeInfo = req.route as { path: string } | undefined;
+    const route = routeInfo?.path ?? req.path;
     const end = this.histogram.startTimer({ method, route });
 
     const record = (statusCode: number) => {

--- a/src/common/interceptors/metrics.interceptor.ts
+++ b/src/common/interceptors/metrics.interceptor.ts
@@ -1,0 +1,48 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { Request, Response } from 'express';
+import { Counter, Histogram } from 'prom-client';
+import { Observable } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+
+@Injectable()
+export class MetricsInterceptor implements NestInterceptor {
+  constructor(
+    @InjectMetric('http_request_duration_seconds')
+    private readonly histogram: Histogram<string>,
+    @InjectMetric('http_requests_total')
+    private readonly counter: Counter<string>,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const req = context.switchToHttp().getRequest<Request>();
+    const res = context.switchToHttp().getResponse<Response>();
+
+    // PrometheusModule 자체 /metrics 엔드포인트는 측정 제외
+    if (req.path === '/metrics') {
+      return next.handle();
+    }
+
+    const method = req.method;
+    const route = (req.route?.path as string | undefined) ?? req.path;
+    const end = this.histogram.startTimer({ method, route });
+
+    const record = (statusCode: number) => {
+      end({ statusCode: String(statusCode) });
+      this.counter.inc({ method, route, statusCode: String(statusCode) });
+    };
+
+    return next.handle().pipe(
+      tap(() => record(res.statusCode)),
+      catchError((err: unknown) => {
+        record(res.statusCode || 500);
+        throw err;
+      }),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import { ResponseInterceptor } from './common/interceptors/response.interceptor'
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.setGlobalPrefix('api');
+  app.setGlobalPrefix('api', { exclude: ['/metrics'] });
 
   app.enableCors({
     origin:


### PR DESCRIPTION
## 관련 이슈
closes #54

## 변경 내용

### 패키지 추가
- `prom-client` — Node.js Prometheus 클라이언트
- `@willsoto/nestjs-prometheus` — NestJS 통합 모듈

### 코드 변경
- `src/main.ts`: `/metrics`를 global prefix(`/api`) 제외 목록에 추가
- `src/app.module.ts`: `PrometheusModule` 등록 (Node.js 기본 메트릭 자동 수집), `MetricsInterceptor` 전역 등록
- `src/common/interceptors/metrics.interceptor.ts` (**신규**): HTTP 요청 duration / count 수집

### 인프라 변경
- `docker-compose.yml`: Prometheus (9090), Grafana (3001) 서비스 추가
- `monitoring/prometheus.yml` (**신규**): 15초 주기로 `/metrics` 스크래핑

## 수집 메트릭

| 메트릭 | 종류 | 레이블 |
|--------|------|--------|
| `http_request_duration_seconds` | Histogram | method, route, statusCode |
| `http_requests_total` | Counter | method, route, statusCode |
| `process_cpu_seconds_total` | Counter | — (자동) |
| `process_resident_memory_bytes` | Gauge | — (자동) |
| `nodejs_eventloop_lag_seconds` | Gauge | — (자동) |
| `nodejs_gc_duration_seconds` | Histogram | — (자동) |

## 검증 방법

```bash
# 1. 앱 실행 후 메트릭 확인
pnpm start:dev
curl http://localhost:3000/metrics

# 2. Docker 환경에서 전체 스택 실행
docker-compose up -d prometheus grafana

# 3. Prometheus UI: http://localhost:9090 → Targets 에서 vitaltrip-server UP 확인
# 4. Grafana: http://localhost:3001 (admin / .env GRAFANA_PASSWORD)
#    → Prometheus 데이터소스 추가 → 대시보드 ID 11159 import
```