### PR TITLE
[FEAT] grafana.aivitaltrip.com 서브도메인 nginx 설정 추가

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -27,8 +27,8 @@ http {
     # HTTP to HTTPS redirect
     server {
         listen 80;
-        server_name node.aivitaltrip.com;
-        return 301 https://$server_name$request_uri;
+        server_name node.aivitaltrip.com grafana.aivitaltrip.com;
+        return 301 https://$host$request_uri;
     }
 
     # HTTPS server
@@ -56,6 +56,30 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_cache_bypass $http_upgrade;
+        }
+    }
+
+    # Grafana
+    server {
+        listen 443 ssl http2;
+        server_name grafana.aivitaltrip.com;
+
+        ssl_certificate /etc/letsencrypt/live/grafana.aivitaltrip.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/grafana.aivitaltrip.com/privkey.pem;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        ssl_prefer_server_ciphers on;
+
+        location / {
+            proxy_pass http://grafana:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 }


### PR DESCRIPTION
## 구현 내용
- `grafana.aivitaltrip.com` 서브도메인으로 Grafana 접속 가능하도록 nginx 설정 추가
- HTTP(80) → HTTPS(443) 리다이렉트에 `grafana.aivitaltrip.com` 추가
- HTTPS 서버 블록 추가 및 Docker 내부 `grafana:3000` 컨테이너로 프록시 연결

## 주요 파일
- `nginx.conf`

## 배포 전 EC2에서 필요한 작업
1. DNS A 레코드 추가: `grafana.aivitaltrip.com` → `54.180.80.9`
2. SSL 인증서 발급:
   ```bash
   sudo certbot certonly --standalone -d grafana.aivitaltrip.com
   ```
3. 컨테이너 재시작:
   ```bash
   docker-compose up -d
   ```

## 접속
```
https://grafana.aivitaltrip.com
```