### PR TITLE
[FEAT] k6 부하테스트 스크립트 추가 및 외부 API mock 모드 구현

### DIFF
--- a/k6/load-test.js
+++ b/k6/load-test.js
@@ -1,0 +1,120 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+
+const errorRate = new Rate('errors');
+const firstAidDuration = new Trend('first_aid_duration');
+const locationDuration = new Trend('location_duration');
+
+export const options = {
+  scenarios: {
+    // 1단계: 워밍업 (10명, 30초)
+    warmup: {
+      executor: 'constant-vus',
+      vus: 10,
+      duration: '30s',
+      tags: { scenario: 'warmup' },
+    },
+    // 2단계: 부하 증가 (10 → 50명, 1분)
+    ramp_up: {
+      executor: 'ramping-vus',
+      startVUs: 10,
+      stages: [
+        { duration: '1m', target: 50 },
+        { duration: '2m', target: 50 },
+        { duration: '30s', target: 0 },
+      ],
+      startTime: '30s',
+      tags: { scenario: 'ramp_up' },
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<2000'],  // 95%가 2초 이내
+    errors: ['rate<0.05'],              // 에러율 5% 미만
+    first_aid_duration: ['p(95)<3000'],
+    location_duration: ['p(95)<1000'],
+  },
+};
+
+// 테스트용 계정 (미리 가입된 계정 필요)
+const TEST_USER = {
+  email: __ENV.TEST_EMAIL || 'loadtest@test.com',
+  password: __ENV.TEST_PASSWORD || 'Test1234!',
+};
+
+export default function () {
+  const scenario = Math.random();
+
+  if (scenario < 0.3) {
+    testAuth();
+  } else if (scenario < 0.6) {
+    testFirstAid();
+  } else {
+    testLocation();
+  }
+
+  sleep(1);
+}
+
+function testAuth() {
+  const res = http.post(
+    `${BASE_URL}/api/auth/login`,
+    JSON.stringify(TEST_USER),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+
+  const ok = check(res, {
+    'login 200': (r) => r.status === 200,
+    'login has token': (r) => {
+      const body = JSON.parse(r.body);
+      return body.data?.accessToken !== undefined;
+    },
+  });
+
+  errorRate.add(!ok);
+}
+
+function testFirstAid() {
+  const start = Date.now();
+
+  const res = http.post(
+    `${BASE_URL}/api/first-aid/advice`,
+    JSON.stringify({
+      symptomType: 'BLEEDING',
+      symptomDetail: '손을 칼에 베였습니다',
+      latitude: 37.5665,
+      longitude: 126.978,
+    }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+
+  firstAidDuration.add(Date.now() - start);
+
+  const ok = check(res, {
+    'first-aid 200': (r) => r.status === 200,
+    'first-aid has content': (r) => {
+      const body = JSON.parse(r.body);
+      return body.data?.content !== undefined;
+    },
+  });
+
+  errorRate.add(!ok);
+}
+
+function testLocation() {
+  const start = Date.now();
+
+  const res = http.get(
+    `${BASE_URL}/api/location/nearby?latitude=37.5665&longitude=126.978&radius=1000&type=HOSPITAL&language=ko`,
+  );
+
+  locationDuration.add(Date.now() - start);
+
+  const ok = check(res, {
+    'location 200': (r) => r.status === 200,
+  });
+
+  errorRate.add(!ok);
+}

--- a/src/first-aid/services/geocoding.service.ts
+++ b/src/first-aid/services/geocoding.service.ts
@@ -14,6 +14,10 @@ export class GeocodingService {
     latitude: number,
     longitude: number,
   ): Promise<GeocodingResult> {
+    if (process.env.LOAD_TEST === 'true') {
+      return { countryCode: 'KR', countryName: 'South Korea' };
+    }
+
     try {
       const { data } = await axios.get<{
         countryCode?: string;

--- a/src/first-aid/services/openai.service.ts
+++ b/src/first-aid/services/openai.service.ts
@@ -95,6 +95,17 @@ export class OpenAiService {
     symptomDetail: string,
     countryCode: string,
   ): Promise<AiAdviceResult> {
+    if (process.env.LOAD_TEST === 'true') {
+      return {
+        content: 'Apply direct pressure to the wound\nKeep the patient calm\nCall emergency services',
+        summary: 'Mock first aid advice for load testing.',
+        recommendedAction: 'Call emergency services immediately.',
+        disclaimer: 'This is mock data for load testing only.',
+        confidence: 90,
+        blogLinks: ['https://www.redcross.org/first-aid'],
+      };
+    }
+
     try {
       const responseLanguage = detectLanguage(symptomDetail);
 

--- a/src/location/services/google-places.service.ts
+++ b/src/location/services/google-places.service.ts
@@ -43,6 +43,22 @@ export class GooglePlacesService {
     type: FacilityType,
     language: string,
   ): Promise<NearbyFacility[]> {
+    if (process.env.LOAD_TEST === 'true') {
+      return [
+        {
+          name: '서울대학교병원',
+          address: '서울특별시 종로구 대학로 101',
+          phoneNumber: '02-2072-2114',
+          latitude: 37.58,
+          longitude: 126.99,
+          distance: 0.5,
+          openNow: true,
+          openingHours: null,
+          websiteUrl: null,
+        },
+      ];
+    }
+
     const cacheKey = `${type}:${latitude.toFixed(2)}:${longitude.toFixed(2)}:${radius}:${language}`;
     const cached = this.cache.get(cacheKey);
     if (cached && Date.now() < cached.expiresAt) {


### PR DESCRIPTION
Closes #57

## 구현 내용
- `GeocodingService`: `LOAD_TEST=true` 시 mock 국가 정보 반환
- `OpenAiService`: `LOAD_TEST=true` 시 mock AI 응급처치 응답 반환
- `GooglePlacesService`: `LOAD_TEST=true` 시 mock 주변 시설 반환
- `k6/load-test.js`: auth/first-aid/location 3가지 시나리오 부하테스트 스크립트

## 주요 파일
- `src/first-aid/services/geocoding.service.ts`
- `src/first-aid/services/openai.service.ts`
- `src/location/services/google-places.service.ts`
- `k6/load-test.js`

## 실행 방법
```bash
# EC2에서 mock 모드로 서버 실행
LOAD_TEST=true docker compose up -d --build app

# k6 부하테스트 실행
k6 run k6/load-test.js \
  -e BASE_URL=https://node.aivitaltrip.com \
  -e TEST_EMAIL=loadtest@test.com \
  -e TEST_PASSWORD=Test1234!
```