### PR TITLE
[REFACTOR] 로그인 API 성능 최적화 - bcrypt 및 DB 커넥션 풀 개선

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -105,7 +105,7 @@ describe('AuthService', () => {
 
       await service.signup(dto);
 
-      expect(bcrypt.hash).toHaveBeenCalledWith(dto.password, 12);
+      expect(bcrypt.hash).toHaveBeenCalledWith(dto.password, 10);
       expect(mockUsersService.create).toHaveBeenCalledWith(
         expect.objectContaining({ email: dto.email, password: 'hashed' }),
       );

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -32,9 +32,9 @@ interface GoogleUserInfo {
   picture: string | null;
 }
 
-const SALT_ROUNDS = 12;
+const SALT_ROUNDS = 10;
 const DUMMY_HASH =
-  '$2b$12$invalidhashpadding00000000000000000000000000000000000000';
+  '$2b$10$invalidhashpadding00000000000000000000000000000000000000';
 
 @Injectable()
 export class AuthService {

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -6,6 +6,16 @@ export class PrismaService
   extends PrismaClient
   implements OnModuleInit, OnModuleDestroy
 {
+  constructor() {
+    super({
+      datasources: {
+        db: {
+          url: `${process.env.DATABASE_URL}?connection_limit=20&pool_timeout=10`,
+        },
+      },
+    });
+  }
+
   async onModuleInit() {
     await this.$connect();
   }


### PR DESCRIPTION
Closes #59

## 문제
k6 부하테스트(100 VUs) 결과

| 지표 | Before |
|------|--------|
| p95 응답시간 | 30.25초 |
| 평균 응답시간 | 21.59초 |
| TPS | 3.25/s |

## 원인 및 개선

### 1. bcrypt SALT_ROUNDS 12 → 10
- cost factor 12는 해싱에 ~300ms 소요
- 10으로 낮추면 ~75ms로 **4배 빠름**
- 보안 수준은 여전히 충분 (OWASP 권장 최소 10)

### 2. Prisma 커넥션 풀 3 → 20
- t2.micro 기준 Prisma 기본 풀 사이즈 = CPU 수 × 2 + 1 = **3개**
- 100명 동시 요청 시 97명이 커넥션 대기
- `connection_limit=20`으로 명시적 설정

## 주요 파일
- `src/auth/auth.service.ts`
- `src/prisma/prisma.service.ts`

## 기대 효과
- p95 응답시간 30초 → 대폭 개선 예상
- TPS 3.25/s → 대폭 향상 예상