### PR TITLE
[REFACTOR] 로그인 API bcrypt 병목 해소 및 DB 조회 select 최적화

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -4,7 +4,7 @@ import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../prisma/prisma.service';
 import { ErrorCode } from '../common/constants/error-codes';
 
-const SALT_ROUNDS = 12;
+const SALT_ROUNDS = 10;
 
 @Injectable()
 export class UsersService {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -35,15 +35,31 @@ export class UsersService {
   }
 
   async findByEmailWithPassword(email: string) {
-    return this.prisma.user.findUnique({ where: { email } });
+    return this.prisma.user.findUnique({
+      where: { email },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        password: true,
+        role: true,
+        provider: true,
+      },
+    });
   }
 
   async findByIdWithRefreshToken(id: number) {
-    return this.prisma.user.findUnique({ where: { id } });
+    return this.prisma.user.findUnique({
+      where: { id },
+      select: { id: true, email: true, role: true, refreshToken: true },
+    });
   }
 
   async findByIdWithPassword(id: number) {
-    return this.prisma.user.findUnique({ where: { id } });
+    return this.prisma.user.findUnique({
+      where: { id },
+      select: { id: true, password: true },
+    });
   }
 
   async findById(id: number) {


### PR DESCRIPTION
## 개요

Closes #61

100 VUs 부하테스트에서 PR #60 적용 후에도 p95=30.52s로 개선이 없던 원인을 추가 분석.
`users.service.ts`의 bcrypt SALT_ROUNDS=12가 누락돼 있어 로그인마다 bcrypt를 두 번 실행하는 병목이 유지됐음.

## 변경 내용

### 1. bcrypt SALT_ROUNDS 12 → 10 (`users.service.ts`)

로그인 흐름:
```
bcrypt.compare(password, storedHash)   ← cost는 저장된 해시 기준
bcrypt.hash(refreshToken, SALT_ROUNDS) ← users.service.ts 기준 (12→10 수정)
```

`auth.service.ts`는 PR #60에서 이미 10으로 변경됐으나, `users.service.ts`는 누락됨.

### 2. DB 조회 select 최적화

| 메서드 | 변경 전 | 변경 후 |
|--------|---------|---------|
| `findByEmailWithPassword` | 전체 컬럼 (refreshToken TEXT 포함) | id, email, name, password, role, provider |
| `findByIdWithRefreshToken` | 전체 컬럼 | id, email, role, refreshToken |
| `findByIdWithPassword` | 전체 컬럼 | id, password |

## 주요 파일

- `src/users/users.service.ts`

## 테스트

- 유닛 테스트 56개 전부 통과
- After 수치: EC2 배포 후 k6 재실행 필요 (테스트 유저 재가입도 함께 필요)

> **참고**: 기존 테스트 유저의 비밀번호 해시가 `$2b$12$...`이므로, 재가입 후 테스트해야 bcrypt.compare도 cost 10으로 실행됨.