### PR TITLE
[FEAT] refreshToken 해싱 bcrypt → SHA-256 교체

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -10,7 +10,7 @@ import { ConfigService } from '@nestjs/config';
 import { UserRole } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 import { AuthService } from './auth.service';
-import { UsersService } from '../users/users.service';
+import { UsersService, hashRefreshToken } from '../users/users.service';
 
 jest.mock('axios');
 jest.mock('bcrypt');
@@ -59,7 +59,7 @@ const mockUser = {
   password: '$2b$12$hashedpassword',
   role: UserRole.USER,
   provider: 'LOCAL',
-  refreshToken: '$2b$12$hashedrefresh',
+  refreshToken: hashRefreshToken('valid.refresh.token'),
   googleId: null,
   appleId: null,
   birthDate: '1990-01-01',
@@ -177,7 +177,6 @@ describe('AuthService', () => {
         email: 'test@example.com',
       });
       mockUsersService.findByIdWithRefreshToken.mockResolvedValue(mockUser);
-      mockedBcrypt.compare.mockResolvedValue(true as never);
       mockUsersService.updateRefreshToken.mockResolvedValue(undefined);
 
       const result = await service.refresh('valid.refresh.token');
@@ -196,13 +195,12 @@ describe('AuthService', () => {
       );
     });
 
-    it('refreshToken bcrypt 불일치 → UnauthorizedException', async () => {
+    it('refreshToken SHA-256 불일치 → UnauthorizedException', async () => {
       mockJwtService.verify.mockReturnValue({
         sub: 1,
         email: 'test@example.com',
       });
       mockUsersService.findByIdWithRefreshToken.mockResolvedValue(mockUser);
-      mockedBcrypt.compare.mockResolvedValue(false as never);
 
       await expect(service.refresh('wrong.refresh.token')).rejects.toThrow(
         UnauthorizedException,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -9,7 +9,7 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import axios from 'axios';
-import { UsersService } from '../users/users.service';
+import { UsersService, compareRefreshToken } from '../users/users.service';
 import { SignupDto } from './dto/signup.dto';
 import { ChangePasswordDto } from './dto/change-password.dto';
 import { ErrorCode } from '../common/constants/error-codes';
@@ -124,7 +124,7 @@ export class AuthService {
 
     const user = await this.usersService.findByIdWithRefreshToken(payload.sub);
     const tokenValid = user?.refreshToken
-      ? await bcrypt.compare(refreshToken, user.refreshToken)
+      ? compareRefreshToken(refreshToken, user.refreshToken)
       : false;
     if (!user || !tokenValid) {
       throw new UnauthorizedException({
@@ -395,7 +395,7 @@ export class AuthService {
 
     const user = await this.usersService.findByIdWithRefreshToken(payload.sub);
     const tokenValid = user?.refreshToken
-      ? await bcrypt.compare(refreshToken, user.refreshToken)
+      ? compareRefreshToken(refreshToken, user.refreshToken)
       : false;
     if (!user || !tokenValid) {
       throw new UnauthorizedException({

--- a/src/first-aid/services/openai.service.ts
+++ b/src/first-aid/services/openai.service.ts
@@ -97,7 +97,8 @@ export class OpenAiService {
   ): Promise<AiAdviceResult> {
     if (process.env.LOAD_TEST === 'true') {
       return {
-        content: 'Apply direct pressure to the wound\nKeep the patient calm\nCall emergency services',
+        content:
+          'Apply direct pressure to the wound\nKeep the patient calm\nCall emergency services',
         summary: 'Mock first aid advice for load testing.',
         recommendedAction: 'Call emergency services immediately.',
         disclaimer: 'This is mock data for load testing only.',

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,11 +1,8 @@
 import { createHash, timingSafeEqual } from 'crypto';
 import { ConflictException, Injectable } from '@nestjs/common';
 import { Prisma, Provider } from '@prisma/client';
-import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../prisma/prisma.service';
 import { ErrorCode } from '../common/constants/error-codes';
-
-const SALT_ROUNDS = 10;
 
 export function hashRefreshToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from 'crypto';
 import { ConflictException, Injectable } from '@nestjs/common';
 import { Prisma, Provider } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
@@ -5,6 +6,17 @@ import { PrismaService } from '../prisma/prisma.service';
 import { ErrorCode } from '../common/constants/error-codes';
 
 const SALT_ROUNDS = 10;
+
+export function hashRefreshToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function compareRefreshToken(token: string, hashed: string): boolean {
+  const tokenHash = Buffer.from(hashRefreshToken(token));
+  const storedHash = Buffer.from(hashed);
+  if (tokenHash.length !== storedHash.length) return false;
+  return timingSafeEqual(tokenHash, storedHash);
+}
 
 @Injectable()
 export class UsersService {
@@ -83,7 +95,7 @@ export class UsersService {
   }
 
   async updateRefreshToken(id: number, refreshToken: string | null) {
-    const hashed = refreshToken ? await bcrypt.hash(refreshToken, SALT_ROUNDS) : null;
+    const hashed = refreshToken ? hashRefreshToken(refreshToken) : null;
     await this.prisma.user.update({
       where: { id },
       data: { refreshToken: hashed },


### PR DESCRIPTION
## 개요

Closes #63

## 배경

현재 로그인 시 refreshToken을 `bcrypt.hash`로 저장, `bcrypt.compare`로 검증.
bcrypt는 사전 공격 방어를 위해 의도적으로 느린 알고리즘 → 비밀번호용 설계.

refreshToken은 서버가 생성한 HMAC-signed JWT(암호학적 랜덤값)이므로 bcrypt의 slow hashing은 오버스펙이며 CPU 병목만 유발.

## 변경 내용

| | 변경 전 | 변경 후 |
|--|---------|---------|
| refreshToken 저장 | `bcrypt.hash(token, 10)` | `SHA-256(token)` |
| refreshToken 검증 | `bcrypt.compare(token, hash)` | SHA-256 재해시 후 `timingSafeEqual` |

- `timingSafeEqual` 사용으로 타이밍 공격 방어 유지
- 비밀번호는 기존과 동일하게 bcrypt 유지

## 기대 효과

로그인 1회당 bcrypt 실행 횟수: **2회 → 1회** (비밀번호 compare만 남음)

## 주요 파일

- `src/users/users.service.ts` — `hashRefreshToken`, `compareRefreshToken` 추가, `updateRefreshToken` 교체
- `src/auth/auth.service.ts` — `compareRefreshToken` 사용
- `src/auth/auth.service.spec.ts` — SHA-256 기반 테스트로 갱신

## 테스트

- 유닛 테스트 56개 전부 통과
- EC2 배포 후 k6 재실행으로 After 수치 측정 필요