### PR TITLE
[FEAT] Node Exporter + cAdvisor 모니터링 스택 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,30 @@ services:
     depends_on:
       - app
 
+  node-exporter:
+    image: prom/node-exporter:latest
+    restart: always
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    restart: always
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+
   prometheus:
     image: prom/prometheus:latest
     restart: always
@@ -58,6 +82,8 @@ services:
       - '9090:9090'
     depends_on:
       - app
+      - node-exporter
+      - cadvisor
 
   grafana:
     image: grafana/grafana:latest

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -7,3 +7,11 @@ scrape_configs:
     static_configs:
       - targets: ['app:3000']
     metrics_path: '/metrics'
+
+  - job_name: 'node-exporter'
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']


### PR DESCRIPTION
## 구현 내용

- `node-exporter` 서비스 추가 — EC2 호스트 CPU/메모리/디스크/네트워크 수집
- `cadvisor` 서비스 추가 — Docker 컨테이너별 리소스 사용량 수집
- Prometheus scrape job 추가 (`node-exporter:9100`, `cadvisor:8080`)

## 모니터링 구조

```
EC2 서버 상태        → node-exporter:9100 ┐
Docker 컨테이너 상태 → cadvisor:8080      ├→ Prometheus → Grafana
NestJS API 상태      → app:3000/metrics   ┘
```

## 주요 파일

- `docker-compose.yml` — node-exporter, cadvisor 서비스 추가 및 prometheus depends_on 갱신
- `monitoring/prometheus.yml` — scrape job 2개 추가

## Grafana 대시보드

배포 후 아래 커뮤니티 대시보드 ID로 바로 사용 가능:
- **1860** — Node Exporter Full
- **14282** — cAdvisor

Closes #65